### PR TITLE
Performance updates

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -13,7 +13,7 @@
   <script type="text/javascript">
     Store.isotopeOptions = {
       transformsEnabled: false,
-      animationEngine : 'best-available',
+      animationEngine : 'css',
       itemSelector: '.product',
       layoutMode: '{{ theme.product_list_layout }}',
       masonry: {

--- a/styles.css
+++ b/styles.css
@@ -112,7 +112,6 @@ img, input, textarea, button, submit, a,
   -moz-transition: opacity .2s ease, color .2s ease, background-color .2s ease;
   -webkit-transition: opacity .2s ease, color .2s ease, background-color .2s ease;
   outline: 0;
-  -webkit-transform: translateZ(0) !important;
   }
 
 /*============================================================
@@ -605,6 +604,7 @@ b, strong {
   height: 100%;
   opacity: 0;
   padding: 0;
+  -webkit-transform: translateZ(0);
   }
 
 .overlay .product_info:hover {
@@ -1311,44 +1311,6 @@ cite a {
 /*============================================================
  Isotope Filtering
 ============================================================*/
-
-.isotope,
-.isotope .isotope-item {
-  /* change duration value to whatever you like */
-  -webkit-transition-duration: 0.8s;
-     -moz-transition-duration: 0.8s;
-      -ms-transition-duration: 0.8s;
-       -o-transition-duration: 0.8s;
-          transition-duration: 0.8s;
-  }
-
-.isotope {
-  -webkit-transition-property: height, width;
-     -moz-transition-property: height, width;
-      -ms-transition-property: height, width;
-       -o-transition-property: height, width;
-          transition-property: height, width;
-  }
-
-.isotope .isotope-item {
-  -webkit-transition-property: -webkit-transform, opacity;
-     -moz-transition-property:    -moz-transform, opacity;
-      -ms-transition-property:     -ms-transform, opacity;
-       -o-transition-property:      -o-transform, opacity;
-          transition-property:         transform, opacity;
-  }
-
-/**** disabling Isotope CSS3 transitions ****/
-
-.isotope.no-transition,
-.isotope.no-transition .isotope-item,
-.isotope .isotope-item.no-transition {
-  -webkit-transition-duration: 0s;
-     -moz-transition-duration: 0s;
-      -ms-transition-duration: 0s;
-       -o-transition-duration: 0s;
-          transition-duration: 0s;
-  }
 
 .isotope-item {
   z-index: 2;


### PR DESCRIPTION
This addresses some performance issues we were seeing with people using sidecar + infinite scrolling with large numbers of products.  It drastically cuts down on the reprocessing of existing isotope elements within the main product list once they've been initialized. 

Tested through both the public facing site and in the custo preview using IE8, 9, FF14, and the latest versions of Safari and Chrome but would love to get some more eyes on it.
