### PR TITLE
Remove title tags on Product page buttons

### DIFF
--- a/source/product.html
+++ b/source/product.html
@@ -85,11 +85,11 @@
             </div>
           {% endif %}
         {% endif %}
-        <button class="button add add-to-cart-button" name="submit" type="submit" title="Add to Cart" data-add-title="Add to Cart" data-sold-title="Sold out"{% if product.has_default_option %}{% else %}disabled="disabled"{% endif %}>Add to Cart</button>
+        <button class="button add add-to-cart-button" name="submit" type="submit" data-add-title="Add to Cart" data-sold-title="Sold out"{% if product.has_default_option %}{% else %}disabled="disabled"{% endif %}>Add to Cart</button>
         {{ store | instant_checkout_button: 'light', '36px' }}
         {% if product.has_option_groups %}
           <div class="reset-selection-button-container">
-            <button class="button minimal-button reset-selection-button" title="Reset selection" type="reset">Reset selection</button>
+            <button class="button minimal-button reset-selection-button" type="reset">Reset selection</button>
           </div>
         {% endif %}
       </form>


### PR DESCRIPTION
The title tag isn't required if it matches the text of the button

Fixes https://www.pivotaltracker.com/story/show/169601583