### PR TITLE
#169601526 alt text & hover styles

### DIFF
--- a/source/home.html
+++ b/source/home.html
@@ -5,7 +5,7 @@
         {% for product in products %}
           <li class="product">
             <a href="{{ product.url }}">
-              <img alt="Image of {{ product.name | escape }}" src="{{ product.image | product_image_url | constrain: 780  }}">
+              <img alt="" src="{{ product.image | product_image_url | constrain: 780  }}">
               <div class="product_info">
                 <div>
                   <p>

--- a/source/layout.html
+++ b/source/layout.html
@@ -16,7 +16,7 @@
           <header>
             <a href="/" title="{{ store.name | escape }}" class="logo {% if theme.logo != blank %} image {% else %} text {% endif %}" >
               {% if theme.logo %}
-                <img src="{{ theme.logo.url }}" alt="{{ store.name }}" {% if theme.logo.width > 150 %}width="150"{% endif %} />
+                <img src="{{ theme.logo.url }}" alt="{{ store.name }} Home" {% if theme.logo.width > 150 %}width="150"{% endif %} />
               {% else %}
                 {{ store.name | escape }}
               {% endif %}

--- a/source/products.html
+++ b/source/products.html
@@ -6,7 +6,7 @@
         {% for product in products %}
           <li class="product">
             <a href="{{ product.url }}">
-              <img alt="Image of {{ product.name | escape }}" src="{{ product.image | product_image_url | constrain: 780 }}">
+              <img alt="" src="{{ product.image | product_image_url | constrain: 780 }}">
               <div class="product_info">
                 <div>
                   <p>

--- a/source/stylesheets/products.css.sass
+++ b/source/stylesheets/products.css.sass
@@ -59,8 +59,8 @@
       position: relative
       -webkit-font-smoothing: antialiased
 
-    .overlay &:hover .product_info, .overlay &:focus .product_info
-      @include opacity(1)
+      .overlay &:hover .product_info, .overlay &:focus .product_info
+        @include opacity(1)
 
     .product_info
       font-weight: 700px


### PR DESCRIPTION
- Ensures product thumbs have a proper state when using keyboard to tab through them
- Removes alt text on product thumb images

Fixes https://www.pivotaltracker.com/story/show/169601526