### PR TITLE
Update markup inside sidebar and main element

### DIFF
--- a/source/javascripts/store.js
+++ b/source/javascripts/store.js
@@ -86,8 +86,8 @@ Store = window.Store = {
     });
   },
   updateCart: function(cart) {
-    $('aside .cart .count, .main header .cart').htmlHighlight(cart.item_count);
-    return $('aside .cart .total').htmlHighlight(Format.money(cart.total, true, true));
+    $('.sidebar .cart .count, .main header .cart').htmlHighlight(cart.item_count);
+    return $('.sidebar .cart .total').htmlHighlight(Format.money(cart.total, true, true));
   },
   cookiesEnabled: function() {
     var cookieEnabled;

--- a/source/layout.html
+++ b/source/layout.html
@@ -11,7 +11,7 @@
 
   <body id="{{ page.permalink }}" class="{{ page.category }}" data-search="{{ theme.show_search }}">
     <div class="wrapper">
-      <div class="sidebar">
+      <aside class="sidebar">
         <div>
           <header>
             <a href="/" title="{{ store.name | escape }}" class="logo {% if theme.logo != blank %} image {% else %} text {% endif %}" >
@@ -123,7 +123,7 @@
         <footer>
           <div class="bigcartel-credit">{{ bigcartel_credit }}</div>
         </footer>
-      </div>
+      </aside>
 
       <main class="main {% if theme.show_overlay == 'On rollover' %}overlay{% else %}standard{% endif %}">
         <header>

--- a/source/layout.html
+++ b/source/layout.html
@@ -11,7 +11,7 @@
 
   <body id="{{ page.permalink }}" class="{{ page.category }}" data-search="{{ theme.show_search }}">
     <div class="wrapper">
-      <aside>
+      <div class="sidebar">
         <div>
           <header>
             <a href="/" title="{{ store.name | escape }}" class="logo {% if theme.logo != blank %} image {% else %} text {% endif %}" >
@@ -23,23 +23,23 @@
             </a>
           </header>
 
-          <nav>
+          <nav role="navigation" aria-label="Main">
             <section>
-              <h2 class="title">
+              <div class="title">
                 <a href="/cart" class="cart {% if page.full_url contains '/cart' %}current{% endif %}">
                   <b>Cart</b>
                   <span class="total">{{ cart.total | money: theme.money_format }}</span>
                   <span class="count">{{ cart.item_count }}</span>
                 </a>
-              </h2>
+              </div>
             </section>
 
             <section>
-              <h2 class="title">
+              <div class="title">
                 <a href="/products" class="{% if page.full_url contains '/products' %}current{% endif %}">
                   {{ pages.products.name }}
                 </a>
-              </h2>
+              </div>
 
               {% if theme.show_search %}
                 <form action="/products" method="get" class="search" accept-charset="utf8">
@@ -62,7 +62,7 @@
 
             {% if artists.active != blank %}
               <section>
-                <h2 class="title">Artists</h2>
+                <div class="title">Artists</div>
 
                 <ul>
                   {% for artist in artists.active %}
@@ -121,11 +121,11 @@
         </div>
 
         <footer>
-          <cite>{{ bigcartel_credit }}</cite>
+          <div class="bigcartel-credit">{{ bigcartel_credit }}</div>
         </footer>
-      </aside>
+      </div>
 
-      <div class="main {% if theme.show_overlay == 'On rollover' %}overlay{% else %}standard{% endif %}">
+      <main class="main {% if theme.show_overlay == 'On rollover' %}overlay{% else %}standard{% endif %}">
         <header>
           <a href="/cart" class="cart">{{ cart.item_count }}</a>
           <a href="#" class="menu">Menu<b></b></a>
@@ -140,7 +140,7 @@
         {% else %}
           {{ page_content }}
         {% endif %}
-      </div>
+      </main>
     </div>
 
     <script src="//ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js" type="text/javascript"></script>

--- a/source/stylesheets/layout.css.sass
+++ b/source/stylesheets/layout.css.sass
@@ -251,7 +251,7 @@ textarea
 
 /* @group sidebar */
 
-aside
+.sidebar
   background-color: #{"{{ theme.sidebar_color }}"}
   float: left
   height: 100%
@@ -437,7 +437,7 @@ aside
     height: 94px
     padding: 40px 0 30px
 
-    cite a
+    .bigcartel-credit a
       background: url(#{"{{ 'bc_badge.png' | theme_image_url }}"}) no-repeat
       @include background-size(100% 100%)
       display: block


### PR DESCRIPTION
This changes `<aside>` to a regular `<div>`, and specifies that the `<nav>` element is for main navigation. It also swaps the `<h2>` header elements used in the navigation in favor of <div> tags, and changes the `<cite>` to `<div>`. Finally the "main" div is using `<main>` so it can get picked up as a proper landmark.

Fixes https://www.pivotaltracker.com/story/show/169826719