### PR TITLE
Improve Home & Products page contrast

### DIFF
--- a/source/home.html
+++ b/source/home.html
@@ -7,18 +7,14 @@
             <a href="{{ product.url }}">
               <img alt="" src="{{ product.image | product_image_url | constrain: 780  }}">
               <div class="product_info">
-                <div>
-                  <p>
-                    <span class="product_name">{{ product.name }}</span>
-                    <span class="{% if product.on_sale %}sale{% else %}price{% endif %} {{ product.status }}">
-                      {{ product.default_price | money: theme.money_format }}
-                      {% case product.status %}
-                        {% when 'sold-out' %} / Sold Out
-                        {% when 'coming-soon' %} / Coming Soon
-                        {% when 'active' %} {% if product.on_sale %} / On Sale{% endif %}
-                      {% endcase %}
-                    </span>
-                  </p>
+                <div class="product_name">{{ product.name }}</div>
+                <div class="{% if product.on_sale %}sale{% else %}price{% endif %} {{ product.status }}">
+                  {{ product.default_price | money: theme.money_format }}
+                  {% case product.status %}
+                    {% when 'sold-out' %} / Sold Out
+                    {% when 'coming-soon' %} / Coming Soon
+                    {% when 'active' %} {% if product.on_sale %} / On Sale{% endif %}
+                  {% endcase %}
                 </div>
               </div>
             </a>

--- a/source/products.html
+++ b/source/products.html
@@ -8,18 +8,14 @@
             <a href="{{ product.url }}">
               <img alt="" src="{{ product.image | product_image_url | constrain: 780 }}">
               <div class="product_info">
-                <div>
-                  <p>
-                    <span class="product_name">{{ product.name }}</span>
-                    <span class="{% if product.on_sale %}sale{% else %}price{% endif %} {{ product.status }}">
-                      {{ product.default_price | money: theme.money_format }}
-                      {% case product.status %}
-                        {% when 'sold-out' %} / Sold Out
-                        {% when 'coming-soon' %} / Coming Soon
-                        {% when 'active' %} {% if product.on_sale %} / On Sale{% endif %}
-                      {% endcase %}
-                    </span>
-                  </p>
+                <div class="product_name">{{ product.name }}</div>
+                <div class="{% if product.on_sale %}sale{% else %}price{% endif %} {{ product.status }}">
+                  {{ product.default_price | money: theme.money_format }}
+                  {% case product.status %}
+                    {% when 'sold-out' %} / Sold Out
+                    {% when 'coming-soon' %} / Coming Soon
+                    {% when 'active' %} {% if product.on_sale %} / On Sale{% endif %}
+                  {% endcase %}
                 </div>
               </div>
             </a>

--- a/source/stylesheets/products.css.sass
+++ b/source/stylesheets/products.css.sass
@@ -63,62 +63,46 @@
         @include opacity(1)
 
     .product_info
-      font-weight: 700px
-      padding: 15px
+      font-size: 14px
+      font-weight: 700
+      line-height: 1.5em
+      padding: 15px 0
       text-align: center
 
       span
-        font-size: 11px
-        line-height: 1.2em
         margin: 0
 
       @media screen and (max-width: $break-small)
         color: #{"{{ theme.link_color }}"}
-        font-size: 12px
-        line-height: 1.4em
         padding-top: 16px
 
       .product_name
         display: block
         font-weight: bold
 
-      p
-        padding-top: 5px
-
       .overlay &
         @extend %transition
         @include flexbox
         @include justify-content(center)
         @include align-items(center)
+        @include flex-direction(column)
         background-color: #{"{{ theme.link_color }}"}
         color: #{"{{ theme.background_color }}"}
         height: 100%
         left: 0
         @include opacity(0)
+        padding: 15px
         position: absolute
         top: 0
         width: 100%
 
-        > div
-          display: table
-          height: 100%
-          width: 100%
+        .product_name,
+        .sale,
+        .price
+          font-weight: 700
 
-        p
-          display: table-cell
-          height: 100%
-          width: 100%
-          vertical-align: middle
-
-          .product_name,
-          .sale,
-          .price
-            display: block
-            font-weight: 700
-            padding: 5px 30px
-
-            @media screen and (max-width: $break-small)
-              color: #{"{{ theme.background_color }}"}
+          @media screen and (max-width: $break-small)
+            color: #{"{{ theme.background_color }}"}
 
         @media screen and (max-width: $break-small)
           background-color: transparent
@@ -126,29 +110,26 @@
           padding: 5px 0
           position: static
 
-          > div,
-          p
+          > div
             display: block
             height: auto
             margin-bottom: 0
             width: auto
 
-          p
-            .product_name,
-            .sale,
-            .price
-              color: #{"{{ theme.link_color }}"}
-              padding: 5px 0 0
+          .product_name,
+          .sale,
+          .price
+            color: #{"{{ theme.link_color }}"}
+            padding: 5px 0 0
 
-            .product_name
-              font-weight: bold
+          .product_name
+            font-weight: bold
 
 
 .pagination
   display: none
 
 .page-load-status
-  font-size: 12px
   letter-spacing: 2px
   margin-top: 25px
   text-align: center
@@ -160,6 +141,5 @@
     @extend %transition
     color: #{"{{ theme.text_color }}"}
     font-family: #{"{{ theme.font }}"}
-    font-size: 11px
     text-align: center
     margin: 0 auto


### PR DESCRIPTION
This removes quite a bit of extra and duplicate markup, while also meeting the minimum contrast requirements - setting the font to 14px on the product grid.

Fixes https://www.pivotaltracker.com/story/show/169601615