### PR TITLE
Improve cart color contrast and general accessibility

### DIFF
--- a/source/cart.html
+++ b/source/cart.html
@@ -1,9 +1,9 @@
 <div class="page cart">
+  <h1>Cart</h1>
   {% unless cart.items == blank %}
 
     <form method="post" id="cart_form" action="/cart" accept-charset="utf8">
       <input type="hidden" name="utf8" value='✓'>
-      <h1>Cart</h1>
 
       {% if errors != blank %}
         <ul class="errors">
@@ -13,75 +13,60 @@
         </ul>
       {% endif %}
 
-
-      <ul>
+      <ul class="cart_items">
         {% for item in cart.items %}
           <li class="cart_item" data-item-id="{{ item.id }}">
-            <div class="col1">
-              <a href="{{ item.product.url }}" style="background-image: url('{{ item.product.image | product_image_url: "thumb" }}'); background-size: {% if item.product.image.width < item.product.image.height %}auto 50px;{% else %}50px auto;{% endif %}" class="product_image">
-                {{ item.name }}
+            <div class="cart_product_image">
+              <a title="{{ item.name | escape }}" href="{{ item.product.url }}" style="background-image: url('{{ item.product.image | product_image_url: "thumb" }}'); background-size: {% if item.product.image.width < item.product.image.height %}auto 50px;{% else %}50px auto;{% endif %}" class="product_image"></a>
+            </div>
+            <div class="cart_product_detail">
+              <a href="{{ item.product.url }}">
+                {{ item.product.name }}
               </a>
-              <div>
-                <p class="detail">
-                  <a href="{{ item.product.url }}">
-                    {{ item.product.name }}
-                  </a>
-                  <span class="not_mobile">
-                    {% unless item.product.has_default_option %}
-                      {{ item.option.name }}
-                    {% endunless %}
-                  </span>
-                  <span class="mobile_only">
-                    {% unless item.product.has_default_option %}
-                      {{ item.option.name }} /
-                    {% endunless %}
-                    {{ item.quantity }} @ {{ item.price | money: theme.money_format }}
-                  </span>
-                </p>
-              </div>
+              <span class="not_mobile">
+                {% unless item.product.has_default_option %}
+                  {{ item.option.name }}
+                {% endunless %}
+              </span>
+              <span class="mobile_only">
+                {% unless item.product.has_default_option %}
+                  {{ item.option.name }} /
+                {% endunless %}
+                <span class="cart_item_quantity_update">{{ item.quantity }}</span> @ <span class="cart_item_price_update">{{ item.price | money: theme.money_format }}</span>
+              </span>
+            </div>
+
+            <div class="cart_item_quantity">
+              <label class="item-quantity-label" for="item_{{ item.id }}_qty">Quantity</label>
               {{ item | item_quantity_input }}
             </div>
-            <div class="col2">
-              <div class="not_mobile">
-                <p class="price">
-                  {{ item.price | money: theme.money_format }}
-                </p>
-              </div>
-              <div class="remove">
-                <p>
-                  <a href="#" title="Remove item" class="remove" data-item-id="{{ item.id }}">&times;</a>
-                </p>
-              </div>
+
+            <div class="cart_item_price not_mobile">
+              <span class="cart_item_price_update">{{ item.price | money: theme.money_format }}</span>
+            </div>
+
+            <div class="cart_item_remove">
+              <button title="Remove item" class="remove-item" data-item-id="{{ item.id }}">&times;</button>
             </div>
           </li>
         {% endfor %}
-
-        <li class="total">
-          <div class="col1">
-            <p class="label">
-              Subtotal:
-            </p>
-          </div>
-          <div class="col2">
-            <p>
-              <b class="total_price">{{ cart.total | money: theme.money_format }}</b>
-            </p>
-          </div>
-        </li>
-
-        <li class="submit">
-          <button type="submit" name="checkout" title="Checkout" class="button">
-            Checkout Now
-          </button>
-        </li>
-
       </ul>
+
+      <div class="cart_footer">
+        <div class="cart_subtotal">
+          <span class="cart_subtotal_label">Subtotal:</span>
+          <span class="cart_subtotal_amount">{{ cart.total | money: theme.money_format }}</span>
+        </div>
+        <div class="cart_submit">
+          <button type="submit" name="checkout" class="button">Checkout</button>
+        </div>
+      </div>
+
     </form>
 
   {% endunless %}
   <div class="cart_empty" {% if cart.items != blank %} style="display:none"{% endif %}>
-    <h1>Your cart is empty</h1>
-    <p>Sounds like a good time to <a href="/">start shopping</a>.</p>
+    <p>Your cart is empty! Sounds like a good time to <a href="/">start shopping</a>.</p>
   </div>
 
 </div>

--- a/source/javascripts/cart.js
+++ b/source/javascripts/cart.js
@@ -5,7 +5,7 @@ Store.cart = window.Store.cart = {
     this.timer = null;
     this.form.find('input, select').each(this.setDefaultVal);
     this.form.on('blur change', '[name*="cart[update]"]', $.proxy(this.handleItemUpdate, this));
-    return this.form.on('click', 'a.remove', $.proxy(this.handleItemRemove, this));
+    return this.form.on('click', '.remove-item', $.proxy(this.handleItemRemove, this));
   },
   setDefaultVal: function() {
     var elm;
@@ -58,7 +58,8 @@ Store.cart = window.Store.cart = {
       id = Number(elm.data('item-id'));
       item = cart.items[index - removed];
       if (item && id === item.id) {
-        return elm.find('.price').htmlHighlight(Format.money(item.price, true, true));
+        elm.find('.cart_item_price_update').htmlHighlight(Format.money(item.price, true, true));
+        elm.find('.cart_item_quantity_update').htmlHighlight(item.quantity);
       } else {
         removed++;
         return elm.slideUp('fast', function() {

--- a/source/javascripts/cart.js
+++ b/source/javascripts/cart.js
@@ -69,6 +69,6 @@ Store.cart = window.Store.cart = {
     });
   },
   updateTotal: function(cart) {
-    return $('.total_price', this.form).htmlHighlight(Format.money(cart.total, true, true));
+    return $('.cart_subtotal_amount', this.form).htmlHighlight(Format.money(cart.total, true, true));
   }
 };

--- a/source/stylesheets/cart.css.sass
+++ b/source/stylesheets/cart.css.sass
@@ -1,205 +1,133 @@
-%center-vertical
-  display: table-cell
-  height: 50px
-  vertical-align: middle
-
 .page.cart
   max-width: 720px
   min-width: 500px
   margin: 0 60px 0 260px
+  width: auto
 
   @media screen and (max-width: $break-small)
     max-width: none
-    min-width: 0
     margin: 0
 
     h1
-      display: none
+      padding-top: 23px
 
-  form > ul
+  .cart_items
+    font-size: 15px
+
     @media screen and (max-width: $break-small)
+      margin-top: 32px
       padding: 0 32px
 
-    li
-      border-top-color: #{"{{ theme.border_color }}"}
-      border-top-style: solid
-      border-top-width: 1px
-      height: 70px
+    .cart_item
+      +flexbox
+      +justify-content(flex-start)
+      +align-items(center)
+      border-top: 1px solid #{"{{ theme.border_color }}"}
+      font-size: 15px
       padding: 10px
 
       @media screen and (max-width: $break-small)
-        height: auto
-        overflow: hidden
         padding: 23px 0 32px
         width: 100%
-
-        &:first-child
-          border-top: none
-
-    .col1,
-    .col2
-      @extend %clearfix
-      float: left
-      height: 50px
-      width: 70%
-
-      > div
-        float: left
-
-    .col2
-      float: right
-      width: 28%
-
-      p
-        @extend %center-vertical
-
-    .label
-      font-size: 11px
-      font-weight: 700
-      line-height: 56px
-      text-align: right
-      width: 100%
-
-
-    .cart_item
-      @media screen and (max-width: $break-small)
-        padding: 32px 0
-
-        .col1
-          width: 90%
-
-          > div
-            width: 70%
-
-        .col2
-          width: 22px
-
-        .detail .mobile_only
-          line-height: 1.4
-
 
       .product_image
         background-position: center center
         background-repeat: no-repeat
-        float: left
         display: block
         height: 50px
-        margin-right: 10px
-        overflow: hidden
-        text-indent: -9999px
         width: 50px
 
         img
           max-width: 100% !important
 
-        & + div
-          width: 60%
-
-      p
-        @extend %center-vertical
+      .cart_product_detail
+        padding: 0 50px 0 20px
+        width: 55%
 
         a
-          display: block
-          font-size: 11px
-          font-weight: 700
-          line-height: 14px
+          line-height: 25px
+
+      .item-quantity-label
+        border: 0
+        clip: rect(0 0 0 0)
+        height: 1px
+        margin: -1px
+        overflow: hidden
+        padding: 0
+        position: absolute
+        width: 1px
 
       input[type=text]
-        float: right
-        margin: 8px 0 0
+        font-size: 15px
         text-align: center
         width: 42px
 
-        @media screen and (max-width: $break-small)
-          display: none
+      .cart_item_price
+        padding-left: 20px
 
-      .price
-        font-size: 11px
+      .cart_item_remove
+        margin-left: auto
 
-      div.remove
-        float: right
+        .remove-item
+          background: url(#{"{{ 'remove.png' | theme_image_url }}"}) 0 0 no-repeat
+          border: none
+          @include background-size(22px 22px)
+          cursor: pointer
+          height: 22px
+          text-indent: -9999px
+          width: 22px
 
-      a.remove
-        background: url(#{"{{ 'remove.png' | theme_image_url }}"}) 0 0 no-repeat
-        @include background-size(22px 22px)
-        display: block
-        height: 22px
-        float: right
-        text-indent: -9999px
-        width: 22px
+          &.loading
+            background: url(#{"{{ 'loading.png' | theme_image_url }}"}) 0 0 no-repeat
+            @include animation(spin 1s infinite linear)
 
-        .lt-ie9 &
-          background: url(#{"{{ 'remove1x.png' | theme_image_url }}"}) 0 0 no-repeat
+  .cart_footer
 
-        &.loading
-          background: url(#{"{{ 'loading.png' | theme_image_url }}"}) 0 0 no-repeat
-          @include animation(spin 1s infinite linear)
+    @media screen and(max-width: $break-small)
+      padding: 0 32px
+      width: 100%
 
-    .total
-      font-weight: 700
+  .cart_subtotal
+    +flexbox
+    +align-items(center)
+    border-top: 1px solid #{"{{ theme.border_color }}"}
+    font-size: 15px
+    padding: 20px 10px
 
-      @media screen and (max-width: $break-small)
-        .col1,
-        .col2,
-        .label
-          display: inline
-          width: auto
+    @media screen and (max-width: $break-small)
+      padding: 20px 0
 
-        .label
-          font-size: 12px
+  .cart_subtotal_label
+    text-align: right
+    width: calc(50px + 55% + 45px)
 
-      .col2 p
-        @extend %center-vertical
+    @media screen and (max-width: $break-small)
+      text-align: left
+      width: 100%
 
-      b
-        font-size: 20px
+  .cart_subtotal_amount
+    font-size: 24px
+    padding-left: 18px
+    text-align: left
 
-        @media screen and (max-width: $break-small)
-          font-size: 12px
+  .cart_submit
+    border-top: 1px solid #{"{{ theme.border_color }}"}
+    padding: 20px
+    padding-left: calc(50px + 55% + 62px)
 
-      b + span
-        font-size: 11px
-
-      span
-        display: block
-        font-style: italic
-        font-weight: normal
-
-        @media screen and (max-width: $break-small)
-          display: inline
-
-        &.currency_sign
-          display: inline
-          font-style: normal
-          font-weight: inherit
-
-    .total_price
-      line-height: 1.4
-      position: relative
-      top: 3px
-
-    .submit
-      padding-left: 66%
-
-      @media screen and (max-width: $break-small)
-        border: none
-        padding: 0 16px 25px
+    @media screen and (max-width: $break-small)
+      border-top: none
+      padding-left: 20px
+      text-align: center
 
       button
-        margin: 10px 0 0 35px
-
-        @media screen and (max-width: $break-small)
-          display: block
-          margin: 0 auto
-          width: 60%
+        width: 60%
 
   .cart_empty
-    p
-      font-size: 11px
+    font-size: 15px
 
     @media screen and (max-width: $break-small)
       h1
-        display: block
         margin-bottom: 10px
         padding-top: 29px
 

--- a/source/stylesheets/layout.css.sass
+++ b/source/stylesheets/layout.css.sass
@@ -577,7 +577,6 @@ textarea
     margin: 0
 
     @media screen and (max-width: $break-small)
-      font-size: 16px
       height: auto
       margin-bottom: 0
       padding: 13px 32px 0


### PR DESCRIPTION
This ended up being an all-encompassing PR to fix a number of issues. I know there's a lot of changes but it was a little tricky to figure out how to split this up.

- Markup on links, images, and buttons is all good now
- Restores "Cart" header to display when Cart has items / 0 items
- Restores "Cart" header on mobile devices
- Increases overall sizes
- Adds back the quantity input field on mobile

Fixes https://www.pivotaltracker.com/story/show/169826342
Fixes https://www.pivotaltracker.com/story/show/169829679
Fixes https://www.pivotaltracker.com/story/show/169829772
Fixes https://www.pivotaltracker.com/story/show/169826549
Fixes https://www.pivotaltracker.com/story/show/169826520


Before: 
![image](https://user-images.githubusercontent.com/1694061/69558161-5fb87f00-0f6d-11ea-8f0f-f2e045845211.png)

After:
![image](https://user-images.githubusercontent.com/1694061/69558177-6515c980-0f6d-11ea-9c07-79cc8688fecf.png)

Before:
![image](https://user-images.githubusercontent.com/1694061/69558194-6d6e0480-0f6d-11ea-90e8-de4ad1548376.png)

After:
![image](https://user-images.githubusercontent.com/1694061/69558210-73fc7c00-0f6d-11ea-9674-ac734b3f6c04.png)
