### PR TITLE
Add h1 to Home page for Featured Products and add visuallyhidden class

### DIFF
--- a/source/home.html
+++ b/source/home.html
@@ -1,4 +1,5 @@
 <div class="page home">
+  <h1 class="visuallyhidden">Featured Products</h1>
   {% paginate products from products.all by theme.featured_items %}
     {% if products != blank %}
       <ul class="products_list">

--- a/source/stylesheets/layout.css.sass
+++ b/source/stylesheets/layout.css.sass
@@ -588,4 +588,14 @@ textarea
       @media screen and (max-width: $break-small)
         padding: 20px 32px
 
+.visuallyhidden
+  border: 0
+  clip: rect(0 0 0 0)
+  height: 1px
+  margin: -1px
+  overflow: hidden
+  padding: 0
+  position: absolute
+  width: 1px
+
 /* @end */


### PR DESCRIPTION
This allows us to still have an h1 for assistive technologies, but it isn't needed in the design.

Fixes https://www.pivotaltracker.com/story/show/169601473