### PR TITLE
Accessible cart item image

### DIFF
--- a/source/cart.html
+++ b/source/cart.html
@@ -17,7 +17,9 @@
         {% for item in cart.items %}
           <li class="cart_item" data-item-id="{{ item.id }}">
             <div class="cart_product_image">
-              <a title="{{ item.name | escape }}" href="{{ item.product.url }}" style="background-image: url('{{ item.product.image | product_image_url: "thumb" }}'); background-size: {% if item.product.image.width < item.product.image.height %}auto 50px;{% else %}50px auto;{% endif %}" class="product_image"></a>
+              <a class="cart_product_image_link" href="{{ item.product.url }}">
+                <img src="{{ item.product.image | product_image_url | constrain: 100, 100 }}" alt="{{ item.product.name | escape }}">
+              </a>
             </div>
             <div class="cart_product_detail">
               <a href="{{ item.product.url }}">

--- a/source/stylesheets/cart.css.sass
+++ b/source/stylesheets/cart.css.sass
@@ -30,7 +30,7 @@
         padding: 23px 0 32px
         width: 100%
 
-      .product_image
+      .cart_product_image_link
         background-position: center center
         background-repeat: no-repeat
         display: block
@@ -38,7 +38,8 @@
         width: 50px
 
         img
-          max-width: 100% !important
+          object-fit: cover
+          width: 100%
 
       .cart_product_detail
         padding: 0 50px 0 20px


### PR DESCRIPTION
Replaces the inaccessible link w/ background-image with a normal link + image. Allows it to be picked up by screen readers

Fixes https://www.pivotaltracker.com/story/show/169826494