### PR TITLE
fix: shop logo styling on mobile

### DIFF
--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -517,9 +517,10 @@ textarea
     text-align: center
     width: 70%
     justify-content: center
+    align-items: center
 
     &.image
-      height: 100%
+      height: 75%
 
       img
         display: block


### PR DESCRIPTION
Reduce height to 75% and ensure it's vertically centered