### PR TITLE
feat: product status primary secondary colors

### DIFF
--- a/source/home.html
+++ b/source/home.html
@@ -62,13 +62,21 @@
                   <div class="prod-thumb-info-headers">
                     <div class="prod-thumb-name">{{ product.name }}</div>
                     <div class="prod-thumb-price">
-                      {% if product.variable_pricing %}
-                        {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
+                      {% unless product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                        {% if product.variable_pricing %}
+                          {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
+                        {% else %}
+                          {{ product.default_price | money: theme.money_format }}
+                        {% endif %}
+                        {% if product_status != blank %}
+                          <span class="prod-thumb-status">/ {{ product_status }}</span>
+                        {% endif %}
                       {% else %}
-                        {{ product.default_price | money: theme.money_format }}
-                      {% endif %}
-                      {% if product_status != blank %}<span class="prod-thumb-status">/ {{ product_status }}</span>{% endif %}
-                    </div>
+                        {% if product_status != blank %}
+                          <span class="prod-thumb-status">{{ product_status }}</span>
+                        {% endif %}
+                      {% endunless %}
+                    </div>                    
                   </div>
                 </div>
               </a>

--- a/source/home.html
+++ b/source/home.html
@@ -35,6 +35,7 @@
                   image-square
                 {% endif %}
               {% endcapture %}
+              {% capture product_status_class %}{% if product.status == 'active' and product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
               <a class="prod-thumb {{ theme.show_overlay }} {{ theme.grid_image_style }}" href="{{ product.url }}" title="View {{ product.name | escape }}">
                 <div class="prod-thumb-container">
                   <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
@@ -68,14 +69,10 @@
                         {% else %}
                           {{ product.default_price | money: theme.money_format }}
                         {% endif %}
-                        {% if product_status != blank %}
-                          <span class="prod-thumb-status">/ {{ product_status }}</span>
-                        {% endif %}
-                      {% else %}
-                        {% if product_status != blank %}
-                          <span class="prod-thumb-status">{{ product_status }}</span>
-                        {% endif %}
                       {% endunless %}
+                      {% if product_status != blank %}
+                        <span class="prod-thumb-status {{ product_status_class }}">{{ product_status }}</span>
+                      {% endif %}
                     </div>                    
                   </div>
                 </div>

--- a/source/product.html
+++ b/source/product.html
@@ -111,11 +111,22 @@
       {% if forloop.last %}</div>{% endif %}
     {% endfor %}
 
+    {% assign product_status = '' %}
+    {% case product.status %}
+      {% when 'active' %}
+        {% if product.on_sale %}{% assign product_status = 'On sale' %}{% endif %}
+      {% when 'sold-out' %}
+        {% assign product_status = 'Sold out' %}
+      {% when 'coming-soon' %}
+        {% assign product_status = 'Coming soon' %}
+    {% endcase %}
+
     {% if product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
       {% assign hide_price = true %}
     {% else %}
       {% assign hide_price = false %}
     {% endif %}
+    {% capture product_status_class %}{% if product.status == 'active' and product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
     <div class="price">
       {% unless hide_price %}
         {% if product.variable_pricing %}
@@ -124,13 +135,10 @@
           {{ product.default_price | money: theme.money_format }}
         {% endif %}
       {% endunless %}
-      {% if product.status == 'sold-out' %}
-        <i>{% if hide_price %}Sold Out{% else %}/ Sold Out{% endif %}</i>
-      {% elsif product.status == 'coming-soon' %}
-        <i>/ Coming Soon</i>
-      {% endif %}
-      {% if product.on_sale %}
-        <i>/ On Sale</i>
+      {% if product_status == 'Sold out' %}
+        <span class="status {{ product_status_class }}">{% if hide_price %}Sold Out{% else %} Sold Out{% endif %}</span>
+      {% elsif product_status != blank %}
+        <span class="status {{ product_status_class }}">{{ product_status }}</span>
       {% endif %}
     </div>
 

--- a/source/product.html
+++ b/source/product.html
@@ -111,18 +111,24 @@
       {% if forloop.last %}</div>{% endif %}
     {% endfor %}
 
+    {% if product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+      {% assign hide_price = true %}
+    {% else %}
+      {% assign hide_price = false %}
+    {% endif %}
     <div class="price">
-      {% if product.variable_pricing %}
-        {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
-      {% else %}
-        {{ product.default_price | money: theme.money_format }}
+      {% unless hide_price %}
+        {% if product.variable_pricing %}
+          {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
+        {% else %}
+          {{ product.default_price | money: theme.money_format }}
+        {% endif %}
+      {% endunless %}
+      {% if product.status == 'sold-out' %}
+        <i>{% if hide_price %}Sold Out{% else %}/ Sold Out{% endif %}</i>
+      {% elsif product.status == 'coming-soon' %}
+        <i>/ Coming Soon</i>
       {% endif %}
-      {% case product.status %}
-        {% when 'sold-out' %}
-          <i>/ Sold Out</i>
-        {% when 'coming-soon' %}
-          <i>/ Coming Soon</i>
-      {% endcase %}
       {% if product.on_sale %}
         <i>/ On Sale</i>
       {% endif %}

--- a/source/products.html
+++ b/source/products.html
@@ -26,6 +26,7 @@
                 image-square
               {% endif %}
             {% endcapture %}
+            {% capture product_status_class %}{% if product.status == 'active' and product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
             <a class="prod-thumb {{ theme.show_overlay }} {{ theme.grid_image_style }}" href="{{ product.url }}" title="View {{ product.name | escape }}">
               <div class="prod-thumb-container">
                 <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
@@ -59,14 +60,10 @@
                       {% else %}
                         {{ product.default_price | money: theme.money_format }}
                       {% endif %}
-                      {% if product_status != blank %}
-                        <span class="prod-thumb-status">/ {{ product_status }}</span>
-                      {% endif %}
-                    {% else %}
-                      {% if product_status != blank %}
-                        <span class="prod-thumb-status">{{ product_status }}</span>
-                      {% endif %}
                     {% endunless %}
+                    {% if product_status != blank %}
+                      <span class="prod-thumb-status {{ product_status_class }}">{{ product_status }}</span>
+                    {% endif %}
                   </div>
                 </div>
               </div>

--- a/source/products.html
+++ b/source/products.html
@@ -53,12 +53,20 @@
                 <div class="prod-thumb-info-headers">
                   <div class="prod-thumb-name">{{ product.name }}</div>
                   <div class="prod-thumb-price">
-                    {% if product.variable_pricing %}
-                      {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
+                    {% unless product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
+                      {% if product.variable_pricing %}
+                        {{ product.min_price | money: theme.money_format }} - {{ product.max_price | money: theme.money_format }}
+                      {% else %}
+                        {{ product.default_price | money: theme.money_format }}
+                      {% endif %}
+                      {% if product_status != blank %}
+                        <span class="prod-thumb-status">/ {{ product_status }}</span>
+                      {% endif %}
                     {% else %}
-                      {{ product.default_price | money: theme.money_format }}
-                    {% endif %}
-                    {% if product_status != blank %}<span class="prod-thumb-status">/ {{ product_status }}</span>{% endif %}
+                      {% if product_status != blank %}
+                        <span class="prod-thumb-status">{{ product_status }}</span>
+                      {% endif %}
+                    {% endunless %}
                   </div>
                 </div>
               </div>

--- a/source/settings.json
+++ b/source/settings.json
@@ -42,6 +42,8 @@
               "button_text_color": "#FFFFFF",
               "button_background_color": "#374DCA",
               "button_background_hover_color": "#273896",
+              "product_status_text_color_primary": "#B70303",
+              "product_status_text_color_secondary": "#7E7D7D",
               "announcement_message_background_color": "#000000",
               "announcement_message_text_color": "#FFFFFF"
             }
@@ -64,6 +66,8 @@
               "button_text_color": "#333333",
               "button_background_color": "#F8F8F8",
               "button_background_hover_color": "#C6C6C6",
+              "product_status_text_color_primary": "#CF3917",
+              "product_status_text_color_secondary": "#7E7D7D",
               "announcement_message_background_color": "#F8F8F8",
               "announcement_message_text_color": "#333333"
             }
@@ -86,6 +90,8 @@
               "button_text_color": "#FFFFFF",
               "button_background_color": "#203BE1",
               "button_background_hover_color": "#2A2A2C",
+              "product_status_text_color_primary": "#625DF5",
+              "product_status_text_color_secondary": "#7E7D7D",
               "announcement_message_background_color": "#E3E4EA",
               "announcement_message_text_color": "#2A2A2C"
             }
@@ -113,6 +119,8 @@
               "button_text_color": "#0000FF",
               "button_background_color": "#FFE500",
               "button_background_hover_color": "#EBD300",
+              "product_status_text_color_primary": "#FF5733",
+              "product_status_text_color_secondary": "#7E7D7D",
               "announcement_message_background_color": "#0000FF",
               "announcement_message_text_color": "#FFFFFF"
             }
@@ -135,6 +143,8 @@
               "button_text_color": "#FFFFFF",
               "button_background_color": "#F90081",
               "button_background_hover_color": "#D1006C",
+              "product_status_text_color_primary": "#008C99",
+              "product_status_text_color_secondary": "#7E7D7D",
               "announcement_message_background_color": "#F6FF20",
               "announcement_message_text_color": "#0B0423"
             }
@@ -157,6 +167,8 @@
               "button_text_color": "#FFFBFD",
               "button_background_color": "#273896",
               "button_background_hover_color": "#0C143B",
+              "product_status_text_color_primary": "#FF69B4",
+              "product_status_text_color_secondary": "#7E7D7D",
               "announcement_message_background_color": "#FFFA8D",
               "announcement_message_text_color": "#273896"
             }
@@ -233,6 +245,16 @@
       "variable": "button_background_hover_color",
       "label": "Button background hover",
       "default": "#273896"
+    },
+    {
+      "variable": "product_status_text_color_primary",
+      "label": "Product status text (primary)",
+      "default": "#B70303"
+    },
+    {
+      "variable": "product_status_text_color_secondary",
+      "label": "Product status text (secondary)",
+      "default": "#7E7D7D"
     },
     {
       "variable": "announcement_message_background_color",

--- a/source/settings.json
+++ b/source/settings.json
@@ -334,10 +334,18 @@
     },
     {
       "variable": "show_sold_out_product_options",
-      "label": "Show sold out product options",
+      "label": "Show sold out product variants",
       "type": "boolean",
       "default": true,
-      "description": "Shows sold out product options in the Product page dropdowns",
+      "description": "Shows sold out product variants in the Product page dropdowns",
+      "requires": "inventory"
+    },
+    {
+      "variable": "show_sold_out_product_prices",
+      "label": "Show prices for sold out products",
+      "type": "boolean",
+      "default": true,
+      "description": "Show the price of sold out products on product grids and product pages",
       "requires": "inventory"
     },
     {

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -13,6 +13,8 @@
   --sidebar-link-color: #{'{{ theme.sidebar_link_color }}'}
   --sidebar-link-hover-color: #{'{{ theme.sidebar_link_hover_color }}'}
   --sidebar-border-color: #{'rgba(var(--sidebar-border-color-rgb), .4)'}
+  --product-status-text-color-primary: #{'{{ theme.product_status_text_color_primary }}'}
+  --product-status-text-color-secondary: #{'{{ theme.product_status_text_color_secondary }}'}
   --announcement-message-text-color: #{'{{ theme.announcement_message_text_color }}'}
   --announcement-message-background-color: #{'{{ theme.announcement_message_background_color }}'}
 

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -51,9 +51,15 @@
       font-weight: 700
       margin: 4px 0 12px
 
-      i
-        font-style: normal
-        font-size: .925rem
+    .status
+      font-style: normal
+      font-size: .925rem
+      
+      &.status-primary
+        color: var(--product-status-text-color-primary)
+    
+      &.status-secondary
+        color: var(--product-status-text-color-secondary)
 
   #product-quantity
     display: none

--- a/source/stylesheets/products.sass
+++ b/source/stylesheets/products.sass
@@ -128,10 +128,18 @@
   position: relative
   overflow-wrap: break-word
   word-break: break-word
+  font-weight: bold
 
 .prod-thumb-price
-  font-weight: bold
+  font-weight: normal
   margin-top: 4px
+
+.prod-thumb-status
+  &.status-primary
+    color: var(--product-status-text-color-primary)
+  
+  &.status-secondary
+    color: var(--product-status-text-color-secondary)
 
 .pagination
   display: grid


### PR DESCRIPTION
Adds primary and secondary colors for the product status to emphasize on sale more than other statuses. 

Other changes includes:

- Removes the "/" separator since that was looking funky now with color separation. This also allowed some simplification of the liquid code for showing status.
- Invert the bolding on the list pages for product name vs price

Note: this PR is based off #140 branch.

Example style:
![image](https://github.com/user-attachments/assets/86510337-8643-4d46-8f01-3dd5327bf513)
![image](https://github.com/user-attachments/assets/e96db7b3-5f6d-4546-b554-8f5790a62fbf)

Example style 2:
![image](https://github.com/user-attachments/assets/7bc0be78-f617-4c90-969f-3c454b7c07cc)
![image](https://github.com/user-attachments/assets/da05df14-4c6a-4458-a7a5-7ecd5ab7c5cb)
