### PR TITLE
chore: add attributes for data hook and page type on layout

### DIFF
--- a/source/layout.html
+++ b/source/layout.html
@@ -9,7 +9,7 @@
     <style>.preloader * { opacity: 0; }.transition-preloader * { transition: none !important }</style>
   </head>
 
-  <body id="{{ page.permalink }}" class="{{ page.category }} preloader transition-preloader">
+  <body id="{{ page.permalink }}" class="{{ page.category }} preloader transition-preloader" data-bc-page-type="{% if page.category == 'custom' %}custom{% else %}{{ page.permalink }}{% endif %}">
     <a class="skip-link" href="#main">Skip to main content</a>
     {% if theme.show_search %}
       <div id="search-modal" role="dialog" aria-modal="true" aria-hidden="true">
@@ -194,8 +194,8 @@
           {{ powered_by_big_cartel }}
         </footer>
       </aside>
-
       <main class="main" id="main">
+        <header data-bc-hook="header"></header>
         {% if page.category == 'custom' %}
           <div class="page custom">
             <h1>{{ page.name }}</h1>
@@ -204,6 +204,7 @@
         {% else %}
           {{ page_content }}
         {% endif %}
+        <div data-bc-hook="footer"></div>
       </main>
     </div>
     <script>

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Sidecar",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "images": [
     {
       "variable": "logo",


### PR DESCRIPTION
Allows for 3rd party apps to target key regions for adding content. In particular, key for omnisend and email partners to be able to insert content above the footer.

1. Adds `data-bc-hook` attribute to header and footer. Created a new `<header>` element that's empty to go where the logical header is in the main section since this theme has a sidebar.
2. Adds `data-bc-page-type` attribute to the body tag

Note: A much larger change was previously proposed but I've scaled it back to only the above 2 changes foregoing the larger change which is much more complex.
