### PR TITLE
fix: gap for empty header element

### DIFF
--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Sidecar",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "images": [
     {
       "variable": "logo",

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -516,9 +516,9 @@ textarea
 
 .main
   display: grid
-  grid-template-rows: 1fr auto
+  grid-template-rows: 0fr auto 60px auto
   grid-template-columns: 1fr
-  gap: 60px
+  gap: 0
   padding: 60px 32px 0
   width: 100%
 


### PR DESCRIPTION
When empty header element was added to `data-bc-hook` in previous PR, the new element caused spacing issues that slipped through.  

Adjusted CSS to explicitly set the gap to 0 in the first (empty) row, and 60px between the 2nd and 3rd.

before (left) vs after (right)
![image](https://github.com/user-attachments/assets/ffe6fe84-e942-4725-8bde-9171bfbada23)
