### PR TITLE
Sidecar 2.11.0

### DIFF
--- a/source/cart.html
+++ b/source/cart.html
@@ -18,6 +18,10 @@
         </ul>
       {% endif %}
 
+      {% if theme.cart_text != blank %}
+        <div class="message-banner message-banner--cart">{{ theme.cart_text }}</div>
+      {% endif %}
+
       <ul class="cart-items">
         {% for item in cart.items %}
           <li class="cart-item" data-item-id="{{ item.id }}">

--- a/source/cart.html
+++ b/source/cart.html
@@ -1,8 +1,16 @@
+{% comment %}
+  Use page name from Custo if it's been customized, otherwise use the localized default.
+{% endcomment %}
+{% assign page_title = t['navigation.cart'] %}
+{% if page.name != 'Cart' %}
+  {% assign page_title = page.name %}
+{% endif %}
+
 <div class="page cart">
   <div class="cart-header">
-    <h1>{{ page.name }}</h1>
+    <h1>{{ page_title }}</h1>
     {% if cart.item_count > 0 && cart.shareable_link %}
-      <a href="{{ cart.shareable_link }}" class="copy-cart-link" data-clipboard-text="{{ cart.shareable_link }}">Share this cart</a>
+      <a href="{{ cart.shareable_link }}" class="copy-cart-link" data-clipboard-text="{{ cart.shareable_link }}">{{ t['cart.share_this_cart'] }}</a>
     {% endif %}
   </div>
   {% unless cart.items == blank %}
@@ -47,18 +55,18 @@
 
             <div class="cart-qty">
               <div class="qty-holder" data-item-id="{{ item.id }}">
-                <button title="Decrease quantity of {{ item.product.name | escape }}" class="qty-button qty-button--decrease" data-func="decrease" type="button" data-item-id="{{ item.id }}">
+                <button title="-1  {{ item.product.name | escape }}" class="qty-button qty-button--decrease" data-func="decrease" type="button" data-item-id="{{ item.id }}">
                   <svg aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" height="20" width="20"><path d="M5 9h10v2H5z"/><path d="M5 9h10v2H5z"/></svg>
                 </button>
 
                 <input aria-label="Quantity of {{ item.product.name | escape }}" type="number" autocomplete="off" class="product-quantity" name="cart[update][{{ item.id }}]" min="0" value="{{ item.quantity }}" data-item-id="{{ item.id }}">
 
-                <button title="Increase quantity of {{ item.product.name | escape }}" class="qty-button qty-button--increase" data-func="increase" type="button" data-item-id="{{ item.id }}">
+                <button title="+1 {{ item.product.name | escape }}" class="qty-button qty-button--increase" data-func="increase" type="button" data-item-id="{{ item.id }}">
                   <svg aria-hidden="true" fill="currentColor" viewBox="0 0 20 20" height="20" width="20"><path d="M11 5H9v4H5v2h4v4h2v-4h4V9h-4z"/></svg>
                 </button>
               </div>
 
-              <button class="cart-remove-item cart-remove-item--link button minimal-button" data-item-id="{{ item.id }}" type="button">Remove<span class="visuallyhidden"> {{ item.product.name | escape }} from cart</span></button>
+              <button class="cart-remove-item cart-remove-item--link button minimal-button" data-item-id="{{ item.id }}" type="button">{{ t['cart.remove'] }}<span class="visuallyhidden"> {{ item.product.name | escape }}</span></button>
             </div>
 
             <div class="cart-item-price">
@@ -70,11 +78,11 @@
 
       <div class="cart-footer">
         <div class="cart-subtotal" aria-live="polite" aria-atomic="true">
-          <span class="cart-subtotal__label">Subtotal:</span>
+          <span class="cart-subtotal__label">{{ t['cart.subtotal'] }}:</span>
           <span class="cart-subtotal__amount">{{ cart.total | money: theme.money_format }}</span>
         </div>
         <div class="cart-submit">
-          <button type="submit" name="checkout" class="button button--checkout">Checkout</button>
+          <button type="submit" name="checkout" class="button button--checkout">{{ t['cart.checkout'] }}</button>
           {% if theme.show_bnpl_messaging and cart.items != blank %}
             <div id="payment-processor-messaging">
               <div id="paypal-messaging-container" style="height: 0; overflow: hidden;">
@@ -90,7 +98,7 @@
     </form>
   {% else %}
     <div class="alert-message">
-      <div class="alert-message__text">Your cart is empty. <a href="/">Shop now</a>.</div>
+      <div class="alert-message__text">{{ t['cart.empty_cart'] }}</div>
     </div>
   {% endunless %}
 </div>

--- a/source/contact.html
+++ b/source/contact.html
@@ -1,7 +1,15 @@
+{% comment %}
+  Use page name from Custo if it's been customized, otherwise use the localized default.
+{% endcomment %}
+{% assign page_title = t['navigation.contact'] %}
+{% if page.name != 'Contact' %}
+  {% assign page_title = page.name %}
+{% endif %}
+
 <div class="page">
-  <h1>{{ page.name }}</h1>
+  <h1>{{ page_title }}</h1>
   {% if contact.sent %}
-    <p>Thanks! Your message has been sent and we'll get back to you as soon as we can.</p>
+    <p>{{ t['contact.form_success'] }}</p>
   {% else %}
     {% if errors != blank %}
       <ul class="errors">
@@ -17,23 +25,23 @@
       <input type="hidden" name="utf8" value='✓'>
       <fieldset>
         <p class="contact-field">
-          <label for="name">Name:</label>
+          <label for="name">{{ t['contact.name'] }}:</label>
           {{ contact | contact_input: 'name' }}
         </p>
         <p class="contact-field">
-          <label for="email">Email:</label>
+          <label for="email">{{ t['contact.email'] }}:</label>
           {{ contact | contact_input: 'email' }}
         </p>
         <p class="contact-field">
-          <label for="subject">Subject:</label>
+          <label for="subject">{{ t['contact.subject'] }}:</label>
           {{ contact | contact_input: 'subject' }}
         </p>
         <p class="contact-field">
-          <label for="message">Message:</label>
+          <label for="message">{{ t['contact.message'] }}:</label>
           {{ contact | contact_input: 'message' }}
         </p>
         <p class="contact-field">
-          <button id="contact_button" type="submit" name="submit" class="button">Send Message</button>
+          <button id="contact_button" type="submit" name="submit" class="button">{{ t['contact.send_button'] }}</button>
         </p>
         <p class="contact-field captcha">
           <div class="recaptcha-note">{{ contact.recaptcha }}</div>

--- a/source/contact.html
+++ b/source/contact.html
@@ -10,7 +10,7 @@
         {% endfor %}
       </ul>
     {% endif %}
-    {% if theme.contact_text %}
+    {% if theme.contact_text != blank %}
       <div class="message-banner message-banner--contact">{{ theme.contact_text }}</div>
     {% endif %}
     <form method="post" class="contact" action="/contact" accept-charset="utf8">

--- a/source/home.html
+++ b/source/home.html
@@ -123,13 +123,12 @@
           </div>
         </div>
         {% if paginate.pages > 1 %}
-            {% assign all_products_button_text = t['navigation.all_products'] %}
-            {% if all_products_button_text != blank %}
-              <a class="button minimal-button all-products-button" href="/products">
-                {{ all_products_button_text }}<svg aria-hidden="true" width="16" height="15" viewBox="0 0 21 20" xmlns="http://www.w3.org/2000/svg"><path d="M10.445798 0l9.9966372 9.99663714-.0035344.00381736.0035344.0029084L10.445798 20l-1.87436943-1.8743695L15.1964286 11.5H0v-3h15.1964286L8.57142857 1.87436946z" fill-rule="evenodd"></path></svg>
-              </a>
-            {% endif %}          
-          {% endif %}
+          {% assign all_products_button_text = t['navigation.all_products'] %}
+          {% if all_products_button_text != blank %}
+            <a class="button minimal-button all-products-button" href="/products">
+              {{ all_products_button_text }}<svg aria-hidden="true" width="16" height="15" viewBox="0 0 21 20" xmlns="http://www.w3.org/2000/svg"><path d="M10.445798 0l9.9966372 9.99663714-.0035344.00381736.0035344.0029084L10.445798 20l-1.87436943-1.8743695L15.1964286 11.5H0v-3h15.1964286L8.57142857 1.87436946z" fill-rule="evenodd"></path></svg>
+            </a>
+          {% endif %}          
         {% endif %}
       {% else %}
         <div class="alert-message">

--- a/source/home.html
+++ b/source/home.html
@@ -40,7 +40,7 @@
   {% endif %}
 
   {% if theme.featured_items > 0 %}
-    <h1 class="page-title">{{ theme.featured_header }}</h1>
+    <h1 class="page-title">{{ t['home.featured'] }}</h1>
     {% paginate products from products.all by theme.featured_items order:theme.featured_order %}
       {% if products != blank %}
         <div class="product-list-container">
@@ -52,11 +52,13 @@
               {% assign product_status = '' %}
               {% case product.status %}
                 {% when 'active' %}
-                  {% if product.on_sale %}{% assign product_status = 'On sale' %}{% endif %}
+                  {% if product.on_sale %}
+                    {% assign product_status = t['products.on_sale'] %}
+                  {% endif %}
                 {% when 'sold-out' %}
-                  {% assign product_status = 'Sold out' %}
+                  {% assign product_status = t['products.sold_out'] %}
                 {% when 'coming-soon' %}
-                  {% assign product_status = 'Coming soon' %}
+                  {% assign product_status = t['products.coming_soon'] %}
               {% endcase %}
               {% capture image_class %}
                 {% if product.image.height > product.image.width %}
@@ -68,7 +70,7 @@
                 {% endif %}
               {% endcapture %}
               {% capture product_status_class %}{% if product.status == 'active' and product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
-              <a class="prod-thumb {{ theme.show_overlay }} {{ theme.grid_image_style }}" href="{{ product.url }}" title="View {{ product.name | escape }}">
+              <a class="prod-thumb {{ theme.show_overlay }} {{ theme.grid_image_style }}" href="{{ product.url }}" title="{{ product.name | escape }}">
                 <div class="prod-thumb-container">
                   <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
                     <img
@@ -129,7 +131,7 @@
         {% endif %}
       {% else %}
         <div class="alert-message">
-          <div class="alert-message__text">No products found.</div>
+          <div class="alert-message__text">{{ t['products.no_products'] }}</div>
         </div>
       {% endif %}
     {% endpaginate %}

--- a/source/home.html
+++ b/source/home.html
@@ -123,10 +123,12 @@
           </div>
         </div>
         {% if paginate.pages > 1 %}
-          {% if theme.all_products_button_text != blank %}
-          <a class="button minimal-button all-products-button" href="/products">
-            {{ theme.all_products_button_text }}<svg aria-hidden="true" width="16" height="15" viewBox="0 0 21 20" xmlns="http://www.w3.org/2000/svg"><path d="M10.445798 0l9.9966372 9.99663714-.0035344.00381736.0035344.0029084L10.445798 20l-1.87436943-1.8743695L15.1964286 11.5H0v-3h15.1964286L8.57142857 1.87436946z" fill-rule="evenodd"></path></svg>
-          </a>
+            {% assign all_products_button_text = t['navigation.all_products'] %}
+            {% if all_products_button_text != blank %}
+              <a class="button minimal-button all-products-button" href="/products">
+                {{ all_products_button_text }}<svg aria-hidden="true" width="16" height="15" viewBox="0 0 21 20" xmlns="http://www.w3.org/2000/svg"><path d="M10.445798 0l9.9966372 9.99663714-.0035344.00381736.0035344.0029084L10.445798 20l-1.87436943-1.8743695L15.1964286 11.5H0v-3h15.1964286L8.57142857 1.87436946z" fill-rule="evenodd"></path></svg>
+              </a>
+            {% endif %}          
           {% endif %}
         {% endif %}
       {% else %}

--- a/source/javascripts/cart.js
+++ b/source/javascripts/cart.js
@@ -91,7 +91,7 @@ document.querySelector('.copy-cart-link')?.addEventListener('click', async (even
   } else {
     try {
       await navigator.clipboard.writeText(text);
-      link.textContent = 'Link copied!';
+      link.textContent = themeTranslations?.cart?.shareThisCartLinkCopySuccess || 'Link copied!';
       setTimeout(() => {
         link.textContent = originalText;
       }, 2000);

--- a/source/javascripts/cart.js
+++ b/source/javascripts/cart.js
@@ -129,7 +129,7 @@ function updateShareableLink() {
 }
 
 updateCartCounts = (cart) => {
-  const sub_total = Format.money(cart.total, true, true);
+  const sub_total = formatMoney(cart.total, true, true);
   const item_count = cart.item_count;
   const itemOrItems = Format.pluralize(item_count, 'item', 'items');
 
@@ -168,7 +168,7 @@ processUpdate = (input, item_id, new_val, cart) => {
     for (itemIndex = 0; itemIndex < cart.items.length; itemIndex++) {
       if (cart.items[itemIndex].id == item_id) {
         item_price = cart.items[itemIndex].price;
-        formatted_item_price = Format.money(item_price, true, true);
+        formatted_item_price = formatMoney(item_price, true, true);
         let priceElement = document.querySelector('.cart-item-price__update[data-item-id="'+item_id+'"]');
         htmlHighlight(priceElement,formatted_item_price);
       }

--- a/source/javascripts/functions.js
+++ b/source/javascripts/functions.js
@@ -14,7 +14,7 @@ function camelCaseToDash(string) {
  */
 function formatMoney(amount, withDelimiter = true, withSign = true, withCode = false) {
   const currency = window.bigcartel?.account?.currency || 'USD';
-  const locale = window.bigcartel?.account?.currencyLocale || 'en-US';
+  const locale = navigator.language || 'en-US';
   const moneyFormat = window.bigcartel?.account?.moneyFormat || 'sign';
   
   switch (moneyFormat) {

--- a/source/javascripts/functions.js
+++ b/source/javascripts/functions.js
@@ -1,0 +1,65 @@
+function camelCaseToDash(string) {
+  return string.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+}
+
+/**
+ * Format a number as currency based on the shop's settings
+ * 
+ * @param {number} amount - The amount to format
+ * @param {boolean} [withDelimiter=true] - Whether to include thousands delimiter (ignored, kept for compatibility)
+ * @param {boolean} [withSign=true] - Whether to include currency symbol
+ * 
+ * @param {boolean} [withCode=false] - Whether to include currency code
+ * @returns {string} Formatted currency string
+ */
+function formatMoney(amount, withDelimiter = true, withSign = true, withCode = false) {
+  const currency = window.bigcartel?.account?.currency || 'USD';
+  const locale = window.bigcartel?.account?.currencyLocale || 'en-US';
+  const moneyFormat = window.bigcartel?.account?.moneyFormat || 'sign';
+  
+  switch (moneyFormat) {
+    case 'sign':
+      withSign = true;
+      withCode = false;
+      break;
+    case 'code':
+      withSign = false;
+      withCode = true;
+      break;
+    case 'none':
+      withSign = false;
+      withCode = false;
+      break;
+    default:
+      withSign = true;
+      withCode = false;
+  }
+  
+  const currencyFormatter = new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency: currency
+  });
+  
+  let result;
+  
+  if (withSign) {
+    result = currencyFormatter.format(amount);
+  } else {
+    const formatParts = currencyFormatter.formatToParts(amount);
+    const fractionPart = formatParts.find(part => part.type === 'fraction');
+    
+    const decimalFormatter = new Intl.NumberFormat(locale, {
+      style: 'decimal',
+      minimumFractionDigits: fractionPart ? fractionPart.value.length : 0,
+      maximumFractionDigits: fractionPart ? fractionPart.value.length : 0
+    });
+    
+    result = decimalFormatter.format(amount);
+  }
+  
+  if (withCode) {
+    result += ' <span class="currency_code">' + currency + '</span>';
+  }
+  
+  return result;
+}

--- a/source/javascripts/product-option-groups.js
+++ b/source/javascripts/product-option-groups.js
@@ -89,7 +89,7 @@ function enableAddButton(updated_price) {
   var addButtonTitle = addButton.attr('data-add-title');
   addButton.attr("disabled",false);
   if (updated_price) {
-    priceTitle = ' - ' + Format.money(updated_price, true, true);
+    priceTitle = ' - ' + formatMoney(updated_price, true, true);
   }
   else {
     priceTitle = '';

--- a/source/javascripts/product-payment-messaging.js
+++ b/source/javascripts/product-payment-messaging.js
@@ -46,7 +46,7 @@ const PAYMENT_CONFIG = {
       elementId: 'paypal-messaging-element',
       containerId: 'paypal-messaging-container',
       timeouts: {
-        render: 500
+        render: 1000
       },
       pageTypes: {
         product: 'product-details',
@@ -645,6 +645,10 @@ async function showPaypalMessaging(
       container.style.height = 'auto';
       container.style.overflow = 'visible';
       isVisible = true;
+    }
+    
+    if (!isVisible) {
+      console.warn(`[BNPL] PayPal message did not render visibly within the ${PAYMENT_CONFIG.SUPPORTED_PROCESSORS.paypal.timeouts.render}ms timeout.`);
     }
     
     return isVisible;

--- a/source/javascripts/product-payment-messaging.js
+++ b/source/javascripts/product-payment-messaging.js
@@ -278,7 +278,9 @@ async function showBnplMessaging(price = null, options = {}) {
   }
 
   const colors = {
-    backgroundColor: themeColors?.backgroundColor || PAYMENT_CONFIG.DEFAULT_COLORS.background,
+    // Some themes have a content background color so we prioritize that to ensure we are using the correct 
+    // background color for the messaging
+    backgroundColor: themeColors?.contentBackgroundColor || themeColors?.backgroundColor || PAYMENT_CONFIG.DEFAULT_COLORS.background,
     primaryTextColor: themeColors?.primaryTextColor || PAYMENT_CONFIG.DEFAULT_COLORS.text
   };
 

--- a/source/javascripts/store.js
+++ b/source/javascripts/store.js
@@ -33,10 +33,6 @@ document.addEventListener('DOMContentLoaded', function() {
   headTag.appendChild(styleTag);
 });
 
-function camelCaseToDash(string) {
-  return string.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
-}
-
 window.addEventListener("load", () => {
   document.body.classList.remove("transition-preloader");
 });

--- a/source/layout.html
+++ b/source/layout.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>{{ page.name }} | {{ store.name }}</title>
+    <title>{{ store.name }}</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="{{ theme | theme_css_url }}" media="screen" rel="stylesheet" type="text/css">

--- a/source/layout.html
+++ b/source/layout.html
@@ -1,7 +1,24 @@
+{% comment %} Define a consistent title suffix {% endcomment %}
+{% capture title_suffix %} | {{ store.name }}{% endcapture %}
+
+{% comment %} Set default page title {% endcomment %}
+{% assign page_title = page.name | append: title_suffix %}
+
+{% comment %} Handle special page cases {% endcomment %}
+{% if page.name == 'Home' %}
+  {% assign page_title = store.name %}
+{% elsif page.full_url contains '/products' %}
+  {% if page.full_url contains 'search=' %}
+    {% assign page_title = t['products.search_results'] | append: title_suffix %}
+  {% elsif theme.collections %}
+    {% assign page_title = t['navigation.categories'] | append: title_suffix %}
+  {% endif %}
+{% endif %}
+
 <!DOCTYPE html>
 <html>
   <head>
-    <title>{{ store.name }}</title>
+    <title>{{ page_title }}</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="{{ theme | theme_css_url }}" media="screen" rel="stylesheet" type="text/css">

--- a/source/layout.html
+++ b/source/layout.html
@@ -36,7 +36,7 @@
             </button>
             <form class="search-form" name="search" action="/products" method="get" accept-charset="utf8" role="search">
               <input type="hidden" name="utf8" value='✓'>
-              <label for="desktop-search">Search products</label>
+              <label for="desktop-search">{{ t['navigation.search'] }}</label>
               <input class="search-input" id="desktop-search" name="search" type="search" autocomplete="off" />
               <button type="submit" class="button search-button" aria-label="Submit search form">
                 <svg aria-hidden="true" fill="currentColor" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
@@ -65,7 +65,7 @@
           {{ store.name | escape }}
         {% endif %}
       </a>
-      <a href="/cart" class="cart" aria-label="View cart">
+      <a href="/cart" class="cart" aria-label="{{ t['cart.view_cart'] }}">
         <svg aria-hidden="true" fill="currentColor" width="28" height="24" viewBox="0 0 32 28" xmlns="http://www.w3.org/2000/svg"><path d="M25.3749929 27.9999278c1.9329635 0 3.4999917-1.5670227 3.4999917-3.4999862 0-.991796-.4131994-1.8865006-1.0760168-2.5233628.1341029-.1041601.2011543-.1766346.2011543-.2174235V20.124952H11.1430856l-.5134952-2.6249937h17.0846227c.6174225 0 1.1513721-.4303426 1.2824829-1.0337195C30.9224827 7.82207961 31.885376 3.5 31.885376 3.5H7.89030864L7.40576172 0H.65624844v2.62499374h4.38812735L8.85027492 22.0773552c-.60364389.6289048-.9752937 1.4820598-.9752937 2.4225864 0 1.9329635 1.56702813 3.4999862 3.49999168 3.4999862 1.9329635 0 3.4999916-1.5670227 3.4999916-3.4999862 0-.5205981-.2102579-1.3028839-.4693821-1.7499958h7.938801c-.2591242.4471119-.4693821 1.2293977-.4693821 1.7461506 0 1.9368087 1.5670281 3.5038314 3.4999916 3.5038314zm1.2817352-13.1249633H10.1160953L8.40380382 6.1249854H28.5587164l-1.9019883 8.7499791zm-15.2817552 10.937474c-.7237532 0-1.3124969-.5887438-1.3124969-1.3124969 0-.7237532.5887437-1.3124969 1.3124969-1.3124969.7237531 0 1.3124969.5887437 1.3124969 1.3124969 0 .7237531-.5887438 1.3124969-1.3124969 1.3124969zm13.9999666 0c-.7237532 0-1.3124969-.5887438-1.3124969-1.3124969 0-.7237532.5887437-1.3124969 1.3124969-1.3124969s1.3124969.5887437 1.3124969 1.3124969c0 .7237531-.5887437 1.3124969-1.3124969 1.3124969z" fill-rule="nonzero"></path></svg>
         <span class="cart-count">{{ cart.item_count }}</span>
       </a>
@@ -87,23 +87,23 @@
 
         <nav role="navigation" aria-label="Main">
           <section class="sidebar-cart">
-            <a href="/cart" class="cart" aria-label="View cart">
+            <a href="/cart" class="cart" aria-label="{{ t['cart.view_cart'] }}">
               <svg class="cart-icon" aria-hidden="true" fill="currentColor" xmlns="http://www.w3.org/2000/svg" viewBox="0.66 0 31.23 28"><path d="M25.3749929 27.9999278c1.9329635 0 3.4999917-1.5670227 3.4999917-3.4999862 0-.991796-.4131994-1.8865006-1.0760168-2.5233628.1341029-.1041601.2011543-.1766346.2011543-.2174235V20.124952H11.1430856l-.5134952-2.6249937h17.0846227c.6174225 0 1.1513721-.4303426 1.2824829-1.0337195C30.9224827 7.82207961 31.885376 3.5 31.885376 3.5H7.89030864L7.40576172 0H.65624844v2.62499374h4.38812735L8.85027492 22.0773552c-.60364389.6289048-.9752937 1.4820598-.9752937 2.4225864 0 1.9329635 1.56702813 3.4999862 3.49999168 3.4999862 1.9329635 0 3.4999916-1.5670227 3.4999916-3.4999862 0-.5205981-.2102579-1.3028839-.4693821-1.7499958h7.938801c-.2591242.4471119-.4693821 1.2293977-.4693821 1.7461506 0 1.9368087 1.5670281 3.5038314 3.4999916 3.5038314zm1.2817352-13.1249633H10.1160953L8.40380382 6.1249854H28.5587164l-1.9019883 8.7499791zm-15.2817552 10.937474c-.7237532 0-1.3124969-.5887438-1.3124969-1.3124969 0-.7237532.5887437-1.3124969 1.3124969-1.3124969.7237531 0 1.3124969.5887437 1.3124969 1.3124969 0 .7237531-.5887438 1.3124969-1.3124969 1.3124969zm13.9999666 0c-.7237532 0-1.3124969-.5887438-1.3124969-1.3124969 0-.7237532.5887437-1.3124969 1.3124969-1.3124969s1.3124969.5887437 1.3124969 1.3124969c0 .7237531-.5887437 1.3124969-1.3124969 1.3124969z" fill-rule="nonzero"></path></svg>
-              <span class="cart-details">{{ cart.item_count | pluralize: 'item', 'items' }}: {{ cart.total | money: theme.money_format }}</span>
+              <span class="cart-details">{{ cart.item_count | pluralize: t['navigation.item'], t['navigation.items'] }}: {{ cart.total | money: theme.money_format }}</span>
             </a>
           </section>
 
           <section class="sidebar-categories">
             <div class="title">
               <a href="/products">
-                {{ pages.products.name }}
+                {{ t['navigation.products'] }}
               </a>
             </div>
             <ul class="sidebar-links">
               {% if theme.show_search %}
                 <li>
                   <button class="button--open-search link" aria-haspopup="dialog" aria-controls="search-modal">
-                    Search products
+                    {{ t['navigation.search'] }}
                   </button>
                 </li>
               {% endif %}
@@ -144,7 +144,7 @@
               {% endfor %}
               <li>
                 <a href="{{ pages.contact.url }}">
-                  {{ pages.contact.name }}
+                  {{ t['navigation.contact'] }}
                 </a>
               </li>
             </ul>
@@ -280,6 +280,11 @@
         primaryColor: '{{ theme.body_text_color }}',
         borderColor: '{{ theme.body_text_color }}',
         sidebarBorderColor: '{{ theme.sidebar_link_color }}'
+      };
+      const themeTranslations = {
+        cart: {
+          shareThisCartLinkCopySuccess: "{{ t['cart.share_this_cart_link_copy_success'] | replace: '"', '\"' | replace: "'", "\\'" }}"
+        }
       };
     </script>
     {% if theme.announcement_message_text %}

--- a/source/layout.html
+++ b/source/layout.html
@@ -228,7 +228,11 @@
           {% if theme.footer_text != blank and theme.footer_text_position == "end" %}
             <div class="footer-custom-content">{{ theme.footer_text }} </div>
           {% endif %}
-          <div class="footer-credit" data-bc-hook="credit">{{ big_cartel_credit_logo }}</div>
+          <div class="footer-credit" data-bc-hook="credit">
+            {% unless theme.hide_big_cartel_credit %}
+              {{ big_cartel_credit_logo }}
+            %{ endunless %}
+          </div>
         </footer>
       </main>
     </div>

--- a/source/layout.html
+++ b/source/layout.html
@@ -321,9 +321,7 @@
     <script type="text/javascript">
       window.bigcartel = window.bigcartel || {};
       window.bigcartel.account = window.bigcartel.account || {};
-  
       window.bigcartel.account.currency = window.bigcartel.account.currency || "{{ store.currency.code }}";
-      window.bigcartel.account.currencyLocale = window.bigcartel.account.currencyLocale || "{{ store.currency.locale }}";
       window.bigcartel.account.moneyFormat = "{{ theme.money_format }}";
     </script>
     {% if page.full_url contains '/product/' %}

--- a/source/layout.html
+++ b/source/layout.html
@@ -228,7 +228,7 @@
           {% if theme.footer_text != blank and theme.footer_text_position == "end" %}
             <div class="footer-custom-content">{{ theme.footer_text }} </div>
           {% endif %}
-          <div class="footer-credit" data-bc-hook="credit">{{ powered_by_big_cartel }}</div>
+          <div class="footer-credit" data-bc-hook="credit">{{ big_cartel_credit_logo }}</div>
         </footer>
       </main>
     </div>

--- a/source/layout.html
+++ b/source/layout.html
@@ -94,12 +94,17 @@
           </section>
 
           <section class="sidebar-categories">
-            <div class="title">
-              <a href="/products">
-                {{ t['navigation.products'] }}
-              </a>
-            </div>
             <ul class="sidebar-links">
+              <li>
+                <a href="/">
+                  {{ t['navigation.home'] }}
+                </a>
+              </li>
+              <li>
+                <a href="/products">
+                  {{ t['navigation.all_products'] }}
+                </a>
+              </li>
               {% if theme.show_search %}
                 <li>
                   <button class="button--open-search link" aria-haspopup="dialog" aria-controls="search-modal">
@@ -107,6 +112,11 @@
                   </button>
                 </li>
               {% endif %}
+            </ul>
+          </section>
+
+          <section class="sidebar-categories">
+            <ul class="sidebar-links">
               {% for category in categories.active %}
                 <li>
                   <a href="{{ category.url }}">

--- a/source/layout.html
+++ b/source/layout.html
@@ -10,7 +10,6 @@
   </head>
 
   <body id="{{ page.permalink }}" class="{{ page.category }} preloader transition-preloader" data-bc-page-type="{% if page.category == 'custom' %}custom{% else %}{{ page.permalink }}{% endif %}">
-    <a class="skip-link" href="#main">Skip to main content</a>
     {% if theme.show_search %}
       <div id="search-modal" role="dialog" aria-modal="true" aria-hidden="true">
         <div class="modal-content">

--- a/source/layout.html
+++ b/source/layout.html
@@ -319,17 +319,12 @@
     <script src="{{ 'api' | theme_js_url }}" type="text/javascript"></script>
     <script src="{{ theme | theme_js_url }}" type="text/javascript"></script>
     <script type="text/javascript">
-      var formatMoney = Format.money;
-      Format.money = function(number) {
-        {% case theme.money_format %}
-        {% when 'sign' %}
-          return formatMoney(number, true, true, false);
-        {% when 'code' %}
-          return formatMoney(number, true, false, true);
-        {% when 'sign_and_code' %}
-          return formatMoney(number, true, true, true);
-        {% endcase %}
-      };
+      window.bigcartel = window.bigcartel || {};
+      window.bigcartel.account = window.bigcartel.account || {};
+  
+      window.bigcartel.account.currency = window.bigcartel.account.currency || "{{ store.currency.code }}";
+      window.bigcartel.account.currencyLocale = window.bigcartel.account.currencyLocale || "{{ store.currency.locale }}";
+      window.bigcartel.account.moneyFormat = "{{ theme.money_format }}";
     </script>
     {% if page.full_url contains '/product/' %}
       <script>

--- a/source/layout.html
+++ b/source/layout.html
@@ -277,8 +277,8 @@
       const themeOptions = {
         showInventoryBars: {{ theme.show_inventory_bars }},
         showLowInventoryMessages: {{ theme.show_low_inventory_messages }},
-        lowInventoryMessage: "{{ theme.low_inventory_message | replace: '"', '\"' | replace: "'", "\\'" }}",
-        almostSoldOutMessage: "{{ theme.almost_sold_out_message | replace: '"', '\"' | replace: "'", "\\'" }}",
+        lowInventoryMessage: "{{ t['products.low_inventory'] | replace: '"', '\"' | replace: "'", "\\'" }}",
+        almostSoldOutMessage: "{{ t['products.almost_sold_out'] | replace: '"', '\"' | replace: "'", "\\'" }}",
         desktopProductPageImages: '{{ theme.desktop_product_page_images }}',
         mobileProductPageImages: '{{ theme.mobile_product_page_images }}',
         productImageZoom: {{ theme.product_image_zoom }},

--- a/source/layout.html
+++ b/source/layout.html
@@ -247,7 +247,7 @@
           <div class="footer-credit" data-bc-hook="credit">
             {% unless theme.hide_big_cartel_credit %}
               {{ big_cartel_credit_logo }}
-            %{ endunless %}
+            {% endunless %}
           </div>
         </footer>
       </main>

--- a/source/layout.html
+++ b/source/layout.html
@@ -164,14 +164,16 @@
 
       <main class="main" id="main">
         <div data-bc-hook="header"></div>
-        {% if page.category == 'custom' %}
-          <div class="page custom">
-            <h1>{{ page.name }}</h1>
-            <div class="custom-page-content body-text">{{ page_content | paragraphs }}</div>
-          </div>
-        {% else %}
-          {{ page_content }}
-        {% endif %}
+        <div data-bc-hook="content">
+          {% if page.category == 'custom' %}
+            <div class="page custom">
+              <h1>{{ page.name }}</h1>
+              <div class="custom-page-content body-text">{{ page_content | paragraphs }}</div>
+            </div>
+          {% else %}
+            {{ page_content }}
+          {% endif %}
+        </div>
 
         <footer data-bc-hook="footer">
           {% if theme.footer_text != blank and theme.footer_text_position == "start" %}

--- a/source/maintenance.html
+++ b/source/maintenance.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="standalone-page">
   <head>
-    <title>{{ page.name }} | {{ store.name }}</title>
+    <title>{{ store.name }}</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="{{ theme | theme_css_url }}" media="screen" rel="stylesheet" type="text/css">

--- a/source/product.html
+++ b/source/product.html
@@ -260,7 +260,6 @@
     <div class="related-products-container" data-num-products="{{ related_products_limit }}" role="complementary" aria-label="{{ related_products_header }}">
       <div class="related-products-header">
         <h2 class="related-products-title">{{ related_products_header }}</h2>
-        <a class="related-products-view-all-link" href="/products">View all</a>
       </div>
       <div class="product-list-container">
         <div class="related-product-list product-list product-image-{{ theme.product_grid_image_size }} {% if products.size < 2 %}product-list--center{% endif %}">

--- a/source/product.html
+++ b/source/product.html
@@ -114,11 +114,13 @@
     {% assign product_status = '' %}
     {% case product.status %}
       {% when 'active' %}
-        {% if product.on_sale %}{% assign product_status = 'On sale' %}{% endif %}
+        {% if product.on_sale %}
+          {% assign product_status = t['products.on_sale'] %}
+        {% endif %}
       {% when 'sold-out' %}
-        {% assign product_status = 'Sold out' %}
+        {% assign product_status = t['products.sold_out'] %}
       {% when 'coming-soon' %}
-        {% assign product_status = 'Coming soon' %}
+        {% assign product_status = t['products.coming_soon'] %}
     {% endcase %}
 
     {% assign hide_price = false %}
@@ -138,14 +140,14 @@
           {{ product.default_price | money: theme.money_format }}
         {% endif %}
       {% endunless %}
-      {% if product_status == 'Sold out' %}
-        <span class="status {{ product_status_class }}">{% if hide_price %}Sold Out{% else %} Sold Out{% endif %}</span>
+      {% if product.status == 'sold-out' %}
+        <span class="status {{ product_status_class }}">{% if hide_price %}{{ t['products.sold_out'] }}{% else %} {{ t['products.sold_out'] }}{% endif %}</span>
       {% elsif product_status != blank %}
         <span class="status {{ product_status_class }}">{{ product_status }}</span>
       {% endif %}
     </div>
 
-    {% if product.status == "active" and theme.show_bnpl_messaging %}
+    {% if product.status == 'active' and theme.show_bnpl_messaging %}
       <div id="payment-processor-messaging">
         <div id="paypal-messaging-container" style="height: 0; overflow: hidden;">
           <div id="paypal-messaging-element"></div>
@@ -168,8 +170,8 @@
               {% for option_group in product.option_groups %}
                 <div class="select">
                   <div class="select-wrapper">
-                    <select data-unavailable-text="(Unavailable)" data-sold-text="(Sold out)" data-group-id="{{ option_group.id }}" data-group-name="{{ option_group.name | escape }}" class="product_option_group" name="option_group[{{ option_group.id }}]" aria-label="Select {{ option_group.name | escape }}" required>
-                      <option value="" disabled="disabled" selected>Select {{ option_group.name }}</option>
+                    <select data-unavailable-text="(Unavailable)" data-sold-text="({{ t['products.sold_out'] }})" data-group-id="{{ option_group.id }}" data-group-name="{{ option_group.name | escape }}" class="product_option_group" name="option_group[{{ option_group.id }}]" aria-label="Select {{ option_group.name | escape }}" required>
+                      <option value="" disabled="disabled" selected>{{ option_group.name }}</option>
                       {% for value in option_group.values %}
                         <option value="{{ value.id }}" data-name="{{ value.name | escape }}">{{ value.name }}</option>
                       {% endfor %}
@@ -182,10 +184,10 @@
           {% else %}
             <div class="select single-select">
               <div class="select-wrapper">
-                <select class="product_option_select" id="option" name="cart[add][id]" aria-label="Select variant" required>
-                  <option value="" disabled="disabled" selected>Select variant</option>
+                <select class="product_option_select" id="option" name="cart[add][id]" aria-label="{{ t['products.select_variant'] }}" required>
+                  <option value="" disabled="disabled" selected>{{ t['products.select_variant'] }}</option>
                   {% for option in product.options %}
-                    <option value="{{ option.id }}" data-price="{{ option.price }}"{% if option.sold_out %} disabled="disabled" disabled-type="sold-out"{% endif %}>{{ option.name }} {% if option.sold_out %} (Sold out){% endif %}</option>
+                    <option value="{{ option.id }}" data-price="{{ option.price }}"{% if option.sold_out %} disabled="disabled" disabled-type="sold-out"{% endif %}>{{ option.name }} {% if option.sold_out %} ({{ t['products.sold_out'] }}){% endif %}</option>
                   {% endfor %}
                 </select>
                 <svg aria-hidden="true" fill="currentColor" xmlns="http://www.w3.org/2000/svg" width="14"><path d="M14 1h-1c0-1 0-1 0 0L7 6 1 1c0-1 0-1 0 0H0v1l7 6 7-6V1Z"></path></svg>
@@ -194,15 +196,15 @@
           {% endif %}
         {% endif %}
 
-        <button class="button add-to-cart-button" name="submit" type="submit" data-adding-text="Adding..." data-added-text="Added!" data-add-title="Add to cart" data-sold-title="Sold out">
+        <button class="button add-to-cart-button" name="submit" type="submit" data-adding-text="{{ t['products.adding'] }}" data-added-text="{{ t['products.added'] }}" data-add-title="{{ t['products.add_to_cart'] }}" data-sold-title="{{ t['products.sold_out'] }}">
           <svg aria-hidden="true" class="loader" width="24" fill="currentColor" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><style>.spinner_P7sC{transform-origin:center;animation:spinner_svv2 2.5s infinite linear}@keyframes spinner_svv2{100%{transform:rotate(360deg)}}</style><path d="M10.14,1.16a11,11,0,0,0-9,8.92A1.59,1.59,0,0,0,2.46,12,1.52,1.52,0,0,0,4.11,10.7a8,8,0,0,1,6.66-6.61A1.42,1.42,0,0,0,12,2.69h0A1.57,1.57,0,0,0,10.14,1.16Z" class="spinner_P7sC"/></svg>
-          <span class="button-text">Add to cart</span>
+          <span class="button-text">{{ t['products.add_to_cart'] }}</span>
         </button>
 
         <div class="product-form-cart-linker">
           <div class="product-form-cart-linker-slider">
             <a class="product-form-cart-linker-link" href="/cart">
-              <span class="product-form-cart-link-text">Go to cart</span>
+              <span class="product-form-cart-link-text">{{ t['products.view_cart'] }}</span>
               <svg fill="currentColor" aria-hidden="true" class="arrow" width="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 7.12"><path d="M5.99798228 7.12260396L0 1.12462168 1.12462168 0l4.87565104 4.87529072L10.8753783 0 12 1.12462168 6.00201772 7.12260396l-.001745-.00212061z" fill-rule="evenodd"></path></svg>
             </a>
           </div>
@@ -212,7 +214,7 @@
 
         {% if product.has_option_groups %}
           <div class="reset-selection-button-container">
-            <button class="button minimal-button reset-selection-button" type="reset">Reset selection</button>
+            <button class="button minimal-button reset-selection-button" type="reset">{{ t['products.reset'] }}</button>
           </div>
         {% endif %}
       </form>
@@ -228,7 +230,7 @@
       {% case product.status %}
         {% when 'active' %}
           <div class="availability">
-            <h2 class="availability-header">Availability</h2>
+            <h2 class="availability-header">{{ t['products.inventory'] }}</h2>
             <ul>
               {% for option in product.options %}
                 <li>
@@ -237,7 +239,7 @@
                   {% endunless %}
                   <span class="inventory-status">
                     {% if option.sold_out %}
-                      Sold Out
+                      {{ t['products.sold_out'] }}
                     {% else %}
                       {{ option.inventory }}%
                     {% endif %}
@@ -253,7 +255,7 @@
 </div>
 
 {% if theme.show_related_products %}
-  {% assign related_products_header = theme.related_products_header | default: 'You might also like' %}
+  {% assign related_products_header = t['products.related_products'] %}
   {% assign related_products_collection = product.related_products %}
     
   {% if related_products_collection.size > 0 %}
@@ -270,11 +272,13 @@
             {% assign related_product_status = '' %}
             {% case related_product.status %}
               {% when 'active' %}
-                {% if related_product.on_sale %}{% assign related_product_status = 'On sale' %}{% endif %}
+                {% if related_product.on_sale %}
+                  {% assign related_product_status = t['products.on_sale'] %}
+                {% endif %}
               {% when 'sold-out' %}
-                {% assign related_product_status = 'Sold out' %}
+                {% assign related_product_status = t['products.sold_out'] %}
               {% when 'coming-soon' %}
-                {% assign related_product_status = 'Coming soon' %}
+                {% assign related_product_status = t['products.coming_soon'] %}
             {% endcase %}
             {% capture related_product_status_class %}{% if related_product.status == 'active' and related_product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
             {% capture image_class %}
@@ -286,7 +290,7 @@
                 image-square
               {% endif %}
             {% endcapture %}
-            <a class="prod-thumb {{ theme.show_overlay }} {{ theme.grid_image_style }}" href="{{ related_product.url }}" title="View {{ related_product.name | escape }}">
+            <a class="prod-thumb {{ theme.show_overlay }} {{ theme.grid_image_style }}" href="{{ related_product.url }}" title="{{ related_product.name | escape }}">
               <div class="prod-thumb-container">
                 <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
                   <img

--- a/source/product.html
+++ b/source/product.html
@@ -204,7 +204,7 @@
         <div class="product-form-cart-linker">
           <div class="product-form-cart-linker-slider">
             <a class="product-form-cart-linker-link" href="/cart">
-              <span class="product-form-cart-link-text">{{ t['products.view_cart'] }}</span>
+              <span class="product-form-cart-link-text">{{ t['cart.view_cart'] }}</span>
               <svg fill="currentColor" aria-hidden="true" class="arrow" width="18" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 7.12"><path d="M5.99798228 7.12260396L0 1.12462168 1.12462168 0l4.87565104 4.87529072L10.8753783 0 12 1.12462168 6.00201772 7.12260396l-.001745-.00212061z" fill-rule="evenodd"></path></svg>
             </a>
           </div>

--- a/source/product.html
+++ b/source/product.html
@@ -257,9 +257,9 @@
   {% assign related_products_collection = product.related_products %}
     
   {% if related_products_collection.size > 0 %}
-    <div class="related-products-container" data-num-products="{{ related_products_limit }}" role="complementary" aria-label="{{ theme.related_products_header | default: 'You might also like' }}">
+    <div class="related-products-container" data-num-products="{{ related_products_limit }}" role="complementary" aria-label="{{ related_products_header }}">
       <div class="related-products-header">
-        <h2 class="related-products-title">{{ theme.related_products_header | default: 'You might also like' }}</h2>
+        <h2 class="related-products-title">{{ related_products_header }}</h2>
         <a class="related-products-view-all-link" href="/products">View all</a>
       </div>
       <div class="product-list-container">

--- a/source/product.html
+++ b/source/product.html
@@ -1,4 +1,4 @@
-<div class="page product_detail">
+<div class="page product_detail" data-bc-hook="product-container">
   <div class="product-images desktop-{{ theme.desktop_product_page_images }} mobile-{{ theme.mobile_product_page_images }}" data-total-images="{{ product.images.size }}">
     {% if product.images.size > 1 %}
       <div class="splide product-carousel" role="group" aria-label="{{ product.name | escape }} images">

--- a/source/products.html
+++ b/source/products.html
@@ -1,5 +1,15 @@
+{% comment %}
+  Use page name from Custo if it's been customized, otherwise use the localized default.
+{% endcomment %}
+{% assign page_title = t['navigation.products'] %}
+{% if page.full_url contains "search=" %}
+  {% assign page_title = t['products.search_results'] %}
+{% elsif page.name != 'Products' %}
+  {% assign page_title = page.name %}
+{% endif %}
+
 <div class="page products">
-  <h1>{% if page.full_url contains 'search=' %}Product search{% else %}{{ page.name }}{% endif %}</h1>
+  <h1>{{ page_title }}</h1>
   {% paginate products from products.current by theme.products_per_page %}
     {% if products != blank %}
       <div class="product-list-container">
@@ -11,11 +21,13 @@
             {% assign product_status = '' %}
             {% case product.status %}
               {% when 'active' %}
-                {% if product.on_sale %}{% assign product_status = 'On sale' %}{% endif %}
+                {% if product.on_sale %}
+                  {% assign product_status = t['products.on_sale'] %}
+                {% endif %}
               {% when 'sold-out' %}
-                {% assign product_status = 'Sold out' %}
+                {% assign product_status = t['products.sold_out'] %}
               {% when 'coming-soon' %}
-                {% assign product_status = 'Coming soon' %}
+                {% assign product_status = t['products.coming_soon'] %}
             {% endcase %}
             {% capture image_class %}
               {% if product.image.height > product.image.width %}
@@ -27,7 +39,7 @@
               {% endif %}
             {% endcapture %}
             {% capture product_status_class %}{% if product.status == 'active' and product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
-            <a class="prod-thumb {{ theme.show_overlay }} {{ theme.grid_image_style }}" href="{{ product.url }}" title="View {{ product.name | escape }}">
+            <a class="prod-thumb {{ theme.show_overlay }} {{ theme.grid_image_style }}" href="{{ product.url }}" title="{{ product.name | escape }}">
               <div class="prod-thumb-container">
                 <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
                   <img
@@ -84,17 +96,17 @@
 
           <div class="page-arrows">
             {% if paginate.previous.is_link %}
-              <a aria-label="Go to previous page" class="page-link page-link--previous" href="{{ paginate.previous.url }}"><svg aria-hidden="true" fill="currentColor" class="arrow" width="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 7.12"><path d="M5.99798228 7.12260396L0 1.12462168 1.12462168 0l4.87565104 4.87529072L10.8753783 0 12 1.12462168 6.00201772 7.12260396l-.001745-.00212061z" fill-rule="evenodd"></path></svg><span>Previous</span></a>
+              <a aria-label="Go to previous page" class="page-link page-link--previous" href="{{ paginate.previous.url }}"><svg aria-hidden="true" fill="currentColor" class="arrow" width="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 7.12"><path d="M5.99798228 7.12260396L0 1.12462168 1.12462168 0l4.87565104 4.87529072L10.8753783 0 12 1.12462168 6.00201772 7.12260396l-.001745-.00212061z" fill-rule="evenodd"></path></svg><span>{{ t['navigation.previous'] }}</span></a>
             {% else %}
-              <span class="page-link page-link--previous disabled"><svg aria-hidden="true" fill="currentColor" class="arrow" width="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 7.12"><path d="M5.99798228 7.12260396L0 1.12462168 1.12462168 0l4.87565104 4.87529072L10.8753783 0 12 1.12462168 6.00201772 7.12260396l-.001745-.00212061z" fill-rule="evenodd"></path></svg><span>Previous</span></span>
+              <span class="page-link page-link--previous disabled"><svg aria-hidden="true" fill="currentColor" class="arrow" width="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 7.12"><path d="M5.99798228 7.12260396L0 1.12462168 1.12462168 0l4.87565104 4.87529072L10.8753783 0 12 1.12462168 6.00201772 7.12260396l-.001745-.00212061z" fill-rule="evenodd"></path></svg><span>{{ t['navigation.previous'] }}</span></span>
             {% endif %}
 
             {{ paginate | default_pagination, 'page-numbers', 'page-numbers' }}
 
             {% if paginate.next.is_link %}
-              <a aria-label="Go to next page" class="page-link page-link--next" href="{{ paginate.next.url }}"><span>Next</span><svg aria-hidden="true" fill="currentColor" class="arrow" width="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 7.12"><path d="M5.99798228 7.12260396L0 1.12462168 1.12462168 0l4.87565104 4.87529072L10.8753783 0 12 1.12462168 6.00201772 7.12260396l-.001745-.00212061z" fill-rule="evenodd"></path></svg></a>
+              <a aria-label="Go to next page" class="page-link page-link--next" href="{{ paginate.next.url }}"><span>{{ t['navigation.next'] }}</span><svg aria-hidden="true" fill="currentColor" class="arrow" width="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 7.12"><path d="M5.99798228 7.12260396L0 1.12462168 1.12462168 0l4.87565104 4.87529072L10.8753783 0 12 1.12462168 6.00201772 7.12260396l-.001745-.00212061z" fill-rule="evenodd"></path></svg></a>
             {% else %}
-              <span class="page-link page-link--next disabled"><span>Next</span><svg aria-hidden="true" fill="currentColor" class="arrow" width="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 7.12"><path d="M5.99798228 7.12260396L0 1.12462168 1.12462168 0l4.87565104 4.87529072L10.8753783 0 12 1.12462168 6.00201772 7.12260396l-.001745-.00212061z" fill-rule="evenodd"></path></svg></span>
+              <span class="page-link page-link--next disabled"><span>{{ t['navigation.next'] }}</span><svg aria-hidden="true" fill="currentColor" class="arrow" width="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 7.12"><path d="M5.99798228 7.12260396L0 1.12462168 1.12462168 0l4.87565104 4.87529072L10.8753783 0 12 1.12462168 6.00201772 7.12260396l-.001745-.00212061z" fill-rule="evenodd"></path></svg></span>
             {% endif %}
           </div>
 
@@ -102,7 +114,7 @@
       {% endif %}
     {% else %}
       <div class="alert-message">
-        <div class="alert-message__text">No products found.</div>
+        <div class="alert-message__text">{{ t['products.no_products'] }}</div>
       </div>
     {% endif %}
   {% endpaginate %}

--- a/source/settings.json
+++ b/source/settings.json
@@ -624,6 +624,18 @@
       "description": "Shows a product's name & price on hover, or under the image"
     },
     {
+      "variable": "hide_big_cartel_credit",
+      "label": "Hide Big Cartel logo in menus",
+      "section": "global_navigation",
+      "type": "boolean",
+      "default": false,
+      "description": "Choose whether to display the Big Cartel logo in your shop footer and menus",
+      "requires_upsell": {
+        "unless": "feature:theme_hide_big_cartel_credit_eligible",
+        "analytics_product_sub_area": "Hide Watermark"
+      }
+    },
+    {
       "variable": "footer_text",
       "label": "Footer text",
       "section": "global_navigation",

--- a/source/settings.json
+++ b/source/settings.json
@@ -673,6 +673,13 @@
       ]
     },
     {
+      "variable": "welcome_message",
+      "label": "Welcome message",
+      "section": "homepage",
+      "type": "text",
+      "description": "Displays a message on the Home page"
+    },
+    {
       "variable": "featured_header",
       "label": "Featured products header",
       "section": "homepage",

--- a/source/settings.json
+++ b/source/settings.json
@@ -972,7 +972,7 @@
       "sub_section": "navigation",
       "type": "text",
       "default": "Contact",
-      "description": "Text for the 'Contact' link and references to the cart page",
+      "description": "Text for the 'Contact' link and references to the contact page",
       "requires": [ "translation_mode eq manual" ]
     },
     {

--- a/source/settings.json
+++ b/source/settings.json
@@ -701,6 +701,35 @@
       "description": "The number of products featured on the Home page"
     },
     {
+      "variable": "money_format",
+      "label": "Price display",
+      "section": "product_page",
+      "type": "select",
+      "options": [
+        ["Currency sign", "sign"],
+        ["Currency code", "code"],
+        ["No currency indicator", "none"]
+      ],
+      "default": "sign",
+      "description": "Sets how prices appear in your shop"
+    },
+    {
+      "variable": "show_sold_out_product_prices",
+      "label": "Show prices for sold out products",
+      "section": "product_page",
+      "type": "boolean",
+      "default": false,
+      "description": "Show the price of sold out products on product grids and product pages"
+    },
+    {
+      "variable": "show_coming_soon_product_prices",
+      "label": "Show prices for coming soon products",
+      "section": "product_page",
+      "type": "boolean",
+      "default": true,
+      "description": "Show the price of coming soon products on product grids and product pages"
+    },
+    {
       "variable": "show_sold_out_product_options",
       "label": "Show sold out product variants",
       "section": "product_page",
@@ -825,35 +854,6 @@
         "default": false,
         "analytics_label": "BNPL"
       }
-    },
-    {
-      "variable": "show_sold_out_product_prices",
-      "label": "Show prices for sold out products",
-      "section": "general",
-      "type": "boolean",
-      "default": false,
-      "description": "Show the price of sold out products on product grids and product pages"
-    },
-    {
-      "variable": "show_coming_soon_product_prices",
-      "label": "Show prices for coming soon products",
-      "section": "general",
-      "type": "boolean",
-      "default": true,
-      "description": "Show the price of coming soon products on product grids and product pages"
-    },
-    {
-      "variable": "money_format",
-      "label": "Price display",
-      "section": "general",
-      "type": "select",
-      "options": [
-        ["Currency sign", "sign"],
-        ["Currency code", "code"],
-        ["No currency indicator", "none"]
-      ],
-      "default": "sign",
-      "description": "Sets how prices appear in your shop"
     },
     {
       "variable": "border_radius",

--- a/source/settings.json
+++ b/source/settings.json
@@ -891,8 +891,7 @@
       "section": "general",
       "type": "boolean",
       "default": false,
-      "description": "Show the price of sold out products on product grids and product pages",
-      "requires": ["inventory"]
+      "description": "Show the price of sold out products on product grids and product pages"
     },
     {
       "variable": "show_coming_soon_product_prices",

--- a/source/settings.json
+++ b/source/settings.json
@@ -630,7 +630,7 @@
       "type": "boolean",
       "default": false,
       "description": "Choose whether to display the Big Cartel logo in your shop footer and menus",
-      "requires_upsell": {
+      "requires_upgrade": {
         "unless": "feature:theme_hide_big_cartel_credit_eligible",
         "analytics_product_sub_area": "Hide Watermark"
       }
@@ -879,7 +879,7 @@
       "requires": [
         "feature:theme_bnpl_messaging eq visible"
       ],
-      "requires_upsell": {
+      "requires_upgrade": {
         "unless": "feature:buy_now_pay_later",
         "default": false,
         "analytics_label": "BNPL"

--- a/source/settings.json
+++ b/source/settings.json
@@ -641,7 +641,7 @@
       "section": "global_navigation",
       "type": "textarea",
       "max_length": 2048,
-      "description": "Show a custom message to your shop's footer"
+      "description": "Show a custom message in your shop's footer. Accepts HTML for links and styling."
     },
     {
       "variable": "footer_text_position",

--- a/source/settings.json
+++ b/source/settings.json
@@ -908,17 +908,12 @@
       "section": "general",
       "type": "select",
       "options": [
-        [
-          "Currency sign",
-          "sign"
-        ],
-        [
-          "Currency code with sign",
-          "sign_and_code"
-        ]
+        ["Currency sign", "sign"],
+        ["Currency code", "code"],
+        ["No currency indicator", "none"]
       ],
       "default": "sign",
-      "description": "Sets the display of prices in your shop"
+      "description": "Sets how prices appear in your shop"
     },
     {
       "variable": "border_radius",

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Sidecar",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "images": [
     {
       "variable": "logo",

--- a/source/settings.json
+++ b/source/settings.json
@@ -915,33 +915,34 @@
       "variable": "announcement_message_text",
       "label": "Announcement text",
       "section": "messaging",
-      "type": "text",
+      "type": "textarea",
       "max_length": 500,
       "description": "Displays an announcement message on the top of every page"
-    },
-    {
-      "variable": "maintenance_message",
-      "label": "Maintenance mode message",
-      "section": "messaging",
-      "type": "text",
-      "max_length": 2048,
-      "description": "A message visitors see when your shop is in Maintenance Mode",
-      "default": "We're working on our shop right now.<br /><br />Please check back soon."
     },
     {
       "variable": "contact_text",
       "label": "Contact page text",
       "section": "messaging",
-      "type": "text",
+      "type": "textarea",
       "max_length": 1024,
-      "description": "Displays a message on your contact page"
+      "description": "Displays a message at the top of your contact page"
     },
     {
-      "variable": "welcome_message",
-      "label": "Welcome message",
+      "variable": "cart_text",
+      "label": "Cart page text",
       "section": "messaging",
-      "type": "text",
-      "description": "Displays a message on the Home page"
+      "max_length": 1024,
+      "type": "textarea",
+      "description": "Displays a message at the top your cart page when there are items in the cart"
+    },
+    {
+      "variable": "maintenance_message",
+      "label": "Maintenance mode message",
+      "section": "messaging",
+      "type": "textarea",
+      "max_length": 2048,
+      "description": "A message visitors see when your shop is in Maintenance Mode",
+      "default": "We're working on our shop right now.<br /><br />Please check back soon."
     },
     {
       "variable": "instagram_url",

--- a/source/settings.json
+++ b/source/settings.json
@@ -875,11 +875,15 @@
       "section": "product_page",
       "type": "boolean",
       "default": true,
-      "description": "Show payment options prior to checkout on product and cart pages. Requires paid plan.",
+      "description": "Show payment options prior to checkout on product and cart pages. <a href='https://www.bigcartel.com/resources/help/article/boost-sales-and-conversions-with-buy-now-pay-later-payments' target='_blank'>Learn more</a>",
       "requires": [
         "feature:theme_bnpl_messaging eq visible"
       ],
-      "plan_type": "paid"
+      "requires_upsell": {
+        "unless": "feature:buy_now_pay_later",
+        "default": false,
+        "analytics_label": "BNPL"
+      }
     },
     {
       "variable": "show_sold_out_product_prices",

--- a/source/settings.json
+++ b/source/settings.json
@@ -639,7 +639,7 @@
       "variable": "footer_text",
       "label": "Footer text",
       "section": "global_navigation",
-      "type": "text",
+      "type": "textarea",
       "max_length": 2048,
       "description": "Show a custom message to your shop's footer"
     },

--- a/source/settings.json
+++ b/source/settings.json
@@ -875,7 +875,7 @@
       "section": "messaging",
       "type": "textarea",
       "max_length": 500,
-      "description": "Displays an announcement message on the top of every page"
+      "description": "Displays an announcement message on the top of every page. Accepts HTML for links and styling."
     },
     {
       "variable": "contact_text",
@@ -883,7 +883,7 @@
       "section": "messaging",
       "type": "textarea",
       "max_length": 1024,
-      "description": "Displays a message at the top of your contact page"
+      "description": "Displays a message at the top of your contact page. Accepts HTML for links and styling."
     },
     {
       "variable": "cart_text",
@@ -891,7 +891,7 @@
       "section": "messaging",
       "max_length": 1024,
       "type": "textarea",
-      "description": "Displays a message at the top your cart page when there are items in the cart"
+      "description": "Displays a message at the top your cart page when there are items in the cart. Accepts HTML for links and styling."
     },
     {
       "variable": "maintenance_message",
@@ -899,7 +899,7 @@
       "section": "messaging",
       "type": "textarea",
       "max_length": 2048,
-      "description": "A message visitors see when your shop is in Maintenance Mode",
+      "description": "A message visitors see when your shop is in Maintenance Mode. Accepts HTML for links and styling.",
       "default": "We're working on our shop right now.<br /><br />Please check back soon."
     },
     {

--- a/source/settings.json
+++ b/source/settings.json
@@ -625,11 +625,11 @@
     },
     {
       "variable": "hide_big_cartel_credit",
-      "label": "Hide Big Cartel logo in menus",
+      "label": "Hide Big Cartel logo in footer and menus",
       "section": "global_navigation",
       "type": "boolean",
       "default": false,
-      "description": "Choose whether to display the Big Cartel logo in your shop footer and menus",
+      "description": "Choose whether to show attribution to Big Cartel in your shop design",
       "requires_upgrade": {
         "unless": "feature:theme_hide_big_cartel_credit_eligible",
         "analytics_product_sub_area": "Hide Watermark"

--- a/source/settings.json
+++ b/source/settings.json
@@ -692,17 +692,6 @@
       "description": "Displays a message on the Home page"
     },
     {
-      "variable": "featured_header",
-      "label": "Featured products header",
-      "section": "homepage",
-      "type": "text",
-      "description": "Displays above featured products on the Home page",
-      "default": "Featured",
-      "requires": [
-        "featured_items gt 0"
-      ]
-    },
-    {
       "variable": "featured_items",
       "label": "Featured products",
       "section": "homepage",
@@ -710,14 +699,6 @@
       "options": "0..48",
       "default": 24,
       "description": "The number of products featured on the Home page"
-    },
-    {
-      "variable": "all_products_button_text",
-      "label": "All products button text",
-      "section": "homepage",
-      "type": "text",
-      "description": "Displays underneath featured products and links to your Products Page",
-      "default": "All Products"
     },
     {
       "variable": "show_sold_out_product_options",
@@ -769,17 +750,6 @@
       "type": "boolean",
       "default": true,
       "description": "Displays related products on the Product page"
-    },
-    {
-      "variable": "related_products_header",
-      "label": "Related products header",
-      "section": "product_page",
-      "type": "text",
-      "description": "Displays above related products on Products pages",
-      "default": "You might also like",
-      "requires": [
-        "show_related_products eq true"
-      ]
     },
     {
       "variable": "related_products",
@@ -838,35 +808,6 @@
         "inventory",
         "show_inventory_bars eq false",
         "show_low_inventory_messages eq true"
-      ]
-    },
-    {
-      "variable": "low_inventory_message",
-      "label": "Low stock message",
-      "section": "product_page",
-      "type": "text",
-      "max_length": 50,
-      "description": "Message shown when stock drops below your alert level",
-      "default": "Limited quantities available",
-      "requires": [
-        "inventory",
-        "show_inventory_bars eq false",
-        "show_low_inventory_messages eq true"
-      ]
-    },
-    {
-      "variable": "almost_sold_out_message",
-      "label": "Almost sold out message",
-      "section": "product_page",
-      "type": "text",
-      "max_length": 50,
-      "description": "Message shown when stock drops below half your alert level",
-      "default": "Only a few left!",
-      "requires": [
-        "inventory",
-        "show_inventory_bars eq false",
-        "show_low_inventory_messages eq true",
-        "low_inventory_threshold gt 1"
       ]
     },
     {
@@ -961,6 +902,575 @@
       "description": "A message visitors see when your shop is in Maintenance Mode",
       "default": "We're working on our shop right now.<br /><br />Please check back soon."
     },
+    {
+      "variable": "translation_locale",
+      "label": "Language for text in your shop",
+      "section": "translations",
+      "type": "select",
+      "options": "storefront_locales",
+      "default": "en-US",
+      "description": "Language to use for translations"
+    },
+    {
+      "variable": "translation_mode",
+      "label": "Translation mode",
+      "section": "translations",
+      "type": "select",
+      "options": [
+        ["Automatic", "automatic"],
+        ["Manual", "manual"]
+      ],
+      "default": "automatic",
+      "description": "Select how text appears throughout your shop. Automatic uses our default translations for your chosen language. Manual lets you customize individual text elements to improve translations or personalize messaging."
+    },
+
+    // Manual Navigation Translations
+    {
+      "variable": "navigation_home_tr_text",
+      "label": "'Home'",
+      "section": "translations",
+      "sub_section": "navigation",
+      "type": "text",
+      "default": "Home",
+      "description": "Text for the 'Home' navigation link.",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "navigation_search_tr_text",
+      "label": "'Search'",
+      "section": "translations",
+      "sub_section": "navigation",
+      "type": "text",
+      "default": "Search",
+      "description": "Text for the 'Search' navigation link or button.",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "navigation_shop_tr_text",
+      "label": "'Shop'",
+      "section": "translations",
+      "sub_section": "navigation",
+      "type": "text",
+      "default": "Shop",
+      "description": "Text for the 'Shop' navigation links in the header and menus",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "navigation_cart_tr_text",
+      "label": "'Cart'",
+      "section": "translations",
+      "sub_section": "navigation",
+      "type": "text",
+      "default": "Cart",
+      "description": "Text for the 'Cart' link and references to the cart page",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "navigation_contact_tr_text",
+      "label": "'Contact' text",
+      "section": "translations",
+      "sub_section": "navigation",
+      "type": "text",
+      "default": "Contact",
+      "description": "Text for the 'Contact' link and references to the cart page",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "navigation_view_all_tr_text",
+      "label": "'View all'",
+      "section": "translations",
+      "sub_section": "navigation",
+      "type": "text",
+      "default": "View all",
+      "description": "Text for 'View all' links, often in product collections.",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "navigation_view_tr_text",
+      "label": "'View'",
+      "section": "translations",
+      "sub_section": "navigation",
+      "type": "text",
+      "default": "View",
+      "description": "General text for 'View' links or buttons.",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "navigation_next_tr_text",
+      "label": "'Next'",
+      "section": "translations",
+      "sub_section": "navigation",
+      "type": "text",
+      "default": "Next",
+      "description": "Text for 'Next' buttons or links in pagination.",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "navigation_previous_tr_text",
+      "label": "'Previous'",
+      "section": "translations",
+      "sub_section": "navigation",
+      "type": "text",
+      "default": "Previous",
+      "description": "Text for 'Previous' buttons or links in pagination.",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "navigation_all_tr_text",
+      "label": "'All'",
+      "section": "translations",
+      "sub_section": "navigation",
+      "type": "text",
+      "default": "All",
+      "description": "Text abbreviation used for links to all products",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "navigation_all_products_tr_text",
+      "label": "'All products'",
+      "section": "translations",
+      "sub_section": "navigation",
+      "type": "text",
+      "default": "All products",
+      "description": "Text for links pointing to all products.",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "navigation_products_tr_text",
+      "label": "'Products'",
+      "section": "translations",
+      "sub_section": "navigation",
+      "type": "text",
+      "default": "Products",
+      "description": "Text for 'Products' navigation links.",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "navigation_categories_tr_text",
+      "label": "'Categories'",
+      "section": "translations",
+      "sub_section": "navigation",
+      "type": "text",
+      "default": "Categories",
+      "description": "Text for 'Categories' navigation links.",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "navigation_pages_tr_text",
+      "label": "'Pages'",
+      "section": "translations",
+      "sub_section": "navigation",
+      "type": "text",
+      "default": "Pages",
+      "description": "Text for 'Pages' navigation links.",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "navigation_more_tr_text",
+      "label": "'More'",
+      "section": "translations",
+      "sub_section": "navigation",
+      "type": "text",
+      "default": "More",
+      "description": "Text for 'More' navigation menus",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "navigation_social_tr_text",
+      "label": "'Social'",
+      "section": "translations",
+      "sub_section": "navigation",
+      "type": "text",
+      "default": "Follow us",
+      "description": "Text for titles on your social media links",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "navigation_subscribe_tr_text",
+      "label": "'Subscribe'",
+      "section": "translations",
+      "sub_section": "navigation",
+      "type": "text",
+      "default": "Follow us",
+      "description": "Text for links to your Subscribe page if you are using the <a href='/account/payment-options'>Subscriptions Beta</a> feature",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "navigation_back_to_site_tr_text",
+      "label": "'Back to site'",
+      "section": "translations",
+      "sub_section": "navigation",
+      "type": "text",
+      "default": "Back to site",
+      "description": "Text 'Back to site' link in navigation which links to your 'website' configured in your <a href='/account/your-shop'>shop info</a>",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "navigation_newest_tr_text",
+      "label": "'Newest'",
+      "section": "translations",
+      "sub_section": "navigation",
+      "type": "text",
+      "default": "Newest",
+      "description": "Text for 'Newest' labels in menus for product collections",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "navigation_top_selling_tr_text",
+      "label": "'Top-selling'",
+      "section": "translations",
+      "sub_section": "navigation",
+      "type": "text",
+      "default": "Top-selling",
+      "description": "Text for 'Top-selling' labels in menus for product collections",
+      "requires": [ "translation_mode eq manual" ]
+    },
+
+    // Homepage Translations
+    {
+      "variable": "home_featured_products_tr_text",
+      "label": "'Featured products'",
+      "section": "translations",
+      "sub_section": "homepage",
+      "type": "text",
+      "default": "Featured products",
+      "allow_blank": true,
+      "description": "Text for the featured products section on the home page.",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "home_featured_categories_tr_text",
+      "label": "'Featured categories'",
+      "section": "translations",
+      "sub_section": "homepage",
+      "type": "text",
+      "default": "Featured categories",
+      "allow_blank": true,
+      "description": "Text for the featured categories section on the home page.",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "home_featured_tr_text",
+      "label": "'Featured'",
+      "section": "translations",
+      "sub_section": "homepage",
+      "type": "text",
+      "default": "Featured",
+      "allow_blank": true,
+      "description": "Generic title for featured content on the home page.",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "home_all_products_tr_text",
+      "label": "'All products'",
+      "section": "translations",
+      "sub_section": "homepage",
+      "type": "text",
+      "default": "All products",
+      "description": "Button caption for the 'All products' button on the home page.",
+      "requires": [ "translation_mode eq manual" ]
+    },
+  
+    // Manual Product Translations
+    {
+      "variable": "products_add_to_cart_tr_text",
+      "label": "'Add to cart'",
+      "section": "translations",
+      "sub_section": "products",
+      "type": "text",
+      "default": "Add to cart",
+      "description": "Text for the 'Add to cart' buttons",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "products_select_variant_tr_text",
+      "label": "'Select variant'",
+      "section": "translations",
+      "sub_section": "products",
+      "type": "text",
+      "default": "Select variant",
+      "description": "Text for product variant dropdowns and selections",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "products_select_tr_text",
+      "label": "'Select'",
+      "section": "translations",
+      "sub_section": "products",
+      "type": "text",
+      "default": "Select",
+      "description": "Text for the word used before product variant group dropdowns and selections (e.g. 'Select <variant group name>')",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "products_reset_tr_text",
+      "label": "'Reset'",
+      "section": "translations",
+      "sub_section": "products",
+      "type": "text",
+      "default": "Reset",
+      "description": "Text for button shown when resetting product variant selections",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "products_coming_soon_tr_text",
+      "label": "'Coming soon'",
+      "section": "translations",
+      "sub_section": "products",
+      "type": "text",
+      "default": "Coming soon",
+      "description": "Text displayed for products not yet available",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "products_on_sale_tr_text",
+      "label": "'On sale'",
+      "section": "translations",
+      "sub_section": "products",
+      "type": "text",
+      "default": "On sale",
+      "description": "Text indicating a product is on sale",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "products_sold_out_tr_text",
+      "label": "'Sold out'",
+      "section": "translations",
+      "sub_section": "products",
+      "type": "text",
+      "default": "Sold out",
+      "description": "Text displayed when a product is out of stock",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "products_related_products_tr_text",
+      "label": "Related products header",
+      "section": "translations",
+      "sub_section": "products",
+      "type": "text",
+      "description": "Displays above related products on Products pages",
+      "default": "You might also like",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "products_low_inventory_tr_text",
+      "label": "Low stock message",
+      "section": "translations",
+      "sub_section": "products",
+      "type": "text",
+      "max_length": 50,
+      "description": "Message shown when stock drops below your alert level",
+      "default": "Limited quantities available",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "products_almost_sold_out_tr_text",
+      "label": "Almost sold out message",
+      "section": "translations",
+      "sub_section": "products",
+      "type": "text",
+      "max_length": 50,
+      "description": "Message shown on product pages when stock drops below half your alert level",
+      "default": "Only a few left!",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "products_no_products_tr_text",
+      "label": "'No products found'",
+      "section": "translations",
+      "sub_section": "products",
+      "type": "text",
+      "default": "No products found",
+      "description": "Text displayed in status messages when no products are found",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "products_search_results_tr_text",
+      "label": "'Search results'",
+      "section": "translations",
+      "sub_section": "cart",
+      "type": "text",
+      "default": "Search results",
+      "description": "Text displayed when showing title of search results",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "products_in_stock_tr_text",
+      "label": "'In stock'",
+      "section": "translations",
+      "sub_section": "cart",
+      "type": "text",
+      "default": "in stock",
+      "description": "Text displayed next to certain product variants quantities (e.g. '123 in stock')",
+      "requires": [ "translation_mode eq manual" ]
+    },
+
+    // Manual Cart Translations
+    {
+      "variable": "cart_checkout_tr_text",
+      "label": "'Checkout'",
+      "section": "translations",
+      "sub_section": "cart",
+      "type": "text",
+      "default": "Checkout",
+      "description": "Text for the 'Checkout' button or page title",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "cart_share_this_cart_tr_text",
+      "label": "'Share this cart'",
+      "section": "translations",
+      "sub_section": "cart",
+      "type": "text",
+      "default": "Share this cart",
+      "description": "Text for the 'Share this cart' feature",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "cart_share_this_cart_link_copy_success_tr_text",
+      "label": "'Share this cart copy link success message'",
+      "section": "translations",
+      "sub_section": "cart",
+      "type": "text",
+      "default": "Link copied!",
+      "description": "Success message when the cart share link is copied to the clipboard",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "cart_remove_tr_text",
+      "label": "'Remove'",
+      "section": "translations",
+      "sub_section": "cart",
+      "type": "text",
+      "default": "Remove",
+      "description": "Text for link to remove items from the cart",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "cart_subtotal_tr_text",
+      "label": "'Subtotal'",
+      "section": "translations",
+      "sub_section": "cart",
+      "type": "text",
+      "default": "Subtotal",
+      "description": "Text label for the cart subtotal.",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "cart_continue_shopping_tr_text",
+      "label": "'Continue shopping'",
+      "section": "translations",
+      "sub_section": "cart",
+      "type": "text",
+      "default": "Continue shopping",
+      "description": "Text for the 'Continue shopping' link or button",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "cart_view_cart_tr_text",
+      "label": "'View cart'",
+      "section": "translations",
+      "sub_section": "cart",
+      "type": "text",
+      "default": "View cart",
+      "description": "Text for the 'View cart' link or button",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "cart_empty_cart_tr_text",
+      "label": "'Empty cart'",
+      "section": "translations",
+      "sub_section": "cart",
+      "type": "text",
+      "default": "Your cart is empty",
+      "description": "Text for the empty cart message",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "cart_quantity_abbreviated_tr_text",
+      "label": "'Qty'",
+      "section": "translations",
+      "sub_section": "cart",
+      "type": "text",
+      "default": "Qty",
+      "description": "Text abbreviation for quantity labels",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "cart_quantity_tr_text",
+      "label": "'Quantity'",
+      "section": "translations",
+      "sub_section": "cart",
+      "type": "text",
+      "default": "Quantity",
+      "description": "Text quantity labels",
+      "requires": [ "translation_mode eq manual" ]
+    },
+
+    // Manual Contact Translations
+    {
+      "variable": "contact_name_tr_text",
+      "label": "'Name'",
+      "section": "translations",
+      "sub_section": "contact_form",
+      "type": "text",
+      "default": "Name",
+      "description": "Text for the name field in contact forms.",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "contact_subject_tr_text",
+      "label": "'Subject'",
+      "section": "translations",
+      "sub_section": "contact_form",
+      "type": "text",
+      "default": "Subject",
+      "description": "Text for the subject field in contact forms.",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "contact_email_tr_text",
+      "label": "'Email'",
+      "section": "translations",
+      "sub_section": "contact_form",
+      "type": "text",
+      "default": "Email",
+      "description": "Text for the email field in contact forms.",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "contact_message_tr_text",
+      "label": "'Message'",
+      "section": "translations",
+      "sub_section": "contact_form",
+      "type": "text",
+      "default": "Message",
+      "description": "Text for the message field in contact forms.",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "contact_send_button_tr_text",
+      "label": "'Send message'",
+      "section": "translations",
+      "sub_section": "contact_form",
+      "type": "text",
+      "default": "Send message",
+      "description": "Text for the send button in contact forms.",
+      "requires": [ "translation_mode eq manual" ]
+    },
+    {
+      "variable": "contact_form_success_tr_text",
+      "label": "Contact page submission text",
+      "section": "translations",
+      "sub_section": "contact_form",
+      "type": "text",
+      "max_length": 250,
+      "default": "Thanks! Your message has been sent and we'll get back to you soon.",
+      "description": "Shown when visitor successfully sends a message from the contact form",
+      "requires": [ "translation_mode eq manual" ]
+    },
+
+    // Social Profile URL Settings
     {
       "variable": "instagram_url",
       "label": "Instagram URL",

--- a/source/settings.json
+++ b/source/settings.json
@@ -548,12 +548,12 @@
     },
     {
       "variable": "announcement_message_background_color",
-      "label": "Announcement message background",
+      "label": "Announcement banner background",
       "default": "#000000"
     },
     {
       "variable": "announcement_message_text_color",
-      "label": "Announcement message text",
+      "label": "Announcement banner text",
       "default": "#FFFFFF"
     },
     {
@@ -930,7 +930,7 @@
     },
     {
       "variable": "announcement_message_text",
-      "label": "Announcement text",
+      "label": "Announcement banner",
       "section": "messaging",
       "type": "textarea",
       "max_length": 500,
@@ -938,7 +938,7 @@
     },
     {
       "variable": "contact_text",
-      "label": "Contact page text",
+      "label": "Contact page",
       "section": "messaging",
       "type": "textarea",
       "max_length": 1024,
@@ -946,7 +946,7 @@
     },
     {
       "variable": "cart_text",
-      "label": "Cart page text",
+      "label": "Cart page",
       "section": "messaging",
       "max_length": 1024,
       "type": "textarea",

--- a/source/stylesheets/cart.sass
+++ b/source/stylesheets/cart.sass
@@ -79,6 +79,9 @@
     &::-webkit-outer-spin-button, &::-webkit-inner-spin-button
       display: none
 
+    &:focus
+      outline: 1px solid var(--border-color)
+
   .cart-qty
     display: flex
     align-items: center

--- a/source/stylesheets/cart.sass
+++ b/source/stylesheets/cart.sass
@@ -172,3 +172,14 @@
   button
     margin-bottom: 20px
     width: 100%
+
+.message-banner
+  &--cart
+    border-radius: var(--border-radius)
+    background-color: var(--announcement-message-background-color)
+    color: var(--announcement-message-text-color)
+    padding: 16px
+    margin: 0 auto 32px
+    text-align: center
+    width: 100%
+    max-width: 760px

--- a/source/stylesheets/custom.sass
+++ b/source/stylesheets/custom.sass
@@ -13,3 +13,9 @@
     margin: 0 auto
     max-width: 100%
     margin-bottom: 16px
+
+  iframe
+    display: block
+    margin: 0 auto
+    max-width: 100%
+    margin-bottom: 16px

--- a/source/stylesheets/custom.sass
+++ b/source/stylesheets/custom.sass
@@ -8,6 +8,19 @@
     @media screen and (max-width: $break-small)
       text-align: center
 
+  ol, ul
+    padding-left: 1.5em
+    margin: 1em 0
+
+    ol, ul
+      margin: 0.5em 0
+
+  ul
+    list-style: disc
+
+  ol
+    list-style: decimal
+
   img
     display: inline-block
     margin: 0 auto

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -197,7 +197,6 @@ a.product-form-cart-linker-link
 
 .related-products-container
   padding: 80px 0 100px 0
-  margin-top: -125px
 
   @media screen and (max-width: $break-medium)
     margin-top: 0

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -186,6 +186,9 @@ a.product-form-cart-linker-link
   align-items: center
   margin-bottom: 30px
 
+  @media screen and (max-width: $break-small)
+    display: block
+
   .related-products-title
     font-size: 1.75rem
     margin-bottom: 0

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -101,6 +101,31 @@
     p:last-child
       margin-bottom: 0
 
+    ol, ul
+      padding-left: 1.5em
+      margin: 1em 0
+
+    ol, ul
+      margin: 0.5em 0
+  
+    ul
+      list-style: disc
+
+    ol
+      list-style: decimal
+
+    img
+      display: inline-block
+      margin: 0 auto
+      max-width: 100%
+      margin-bottom: 16px
+
+    iframe
+      display: block
+      margin: 0 auto
+      max-width: 100%
+      margin-bottom: 16px
+
   .availability
     border-top: 1px solid var(--border-color)
     padding-top: 16px

--- a/source/stylesheets/search.sass
+++ b/source/stylesheets/search.sass
@@ -61,6 +61,10 @@
     height: 44px
     padding: 6px 10px
 
+    &:focus
+      outline: none
+      box-shadow: none
+
   .search-button
     color: var(--button-text-color)
     background: var(--button-background-color)

--- a/source/theme.css
+++ b/source/theme.css
@@ -15,6 +15,4 @@ Author: Big Cartel
  *= require stylesheets/all
  */
 
-/*============================================================
-  Custom Styles - add and override styles below.
-============================================================*/
+

--- a/source/theme.js
+++ b/source/theme.js
@@ -1,4 +1,5 @@
 //= require_directory ./javascripts/vendor
+//= require javascripts/functions
 //= require javascripts/store
 //= require javascripts/product
 //= require javascripts/cart


### PR DESCRIPTION
Sidecar v2.11.0 Changes

### Features

- feat: Add comprehensive translation support with automatic and manual modes for theme internationalization
- feat: Setting for controlling visibility of Big Cartel credit in footer and menus
- feat: Custom cart page messaging banner with styling
- feat: Improved money format options with international currency support using Intl.NumberFormat
- feat: Remove inventory management requirement for "hide prices for sold out products" setting

### Fixes

- fix: Custom contact text detection logic corrected to use "!= blank" instead of truthy check
- fix: Override browser default styling on search input focus states
- fix: BNPL messaging background color priority to use content background when available
- fix: Related products header layout wrapping on small mobile viewports

### Chores

- chore: Switch messaging settings from text inputs to textarea fields for better content editing
- chore: Update BNPL setting description with help link and improved upgrade requirements
- chore: Improve SEO with better page title handling for home and maintenance pages
- chore: Increase PayPal BNPL messaging timeout from 500ms to 1000ms with console warnings
- chore: Add focus outline styling to cart quantity inputs for better accessibility
- chore: Remove "View all" link from related products header to simplify layout
- chore: Remove "Skip to main content" accessibility link
- chore: Replace legacy Format.money with new formatMoney function throughout theme
- chore: Update Big Cartel footer credit to use logo-only format
- chore: Add extensive manual translation settings for all theme text elements
- chore: Add `data-bc-hook="content"` for main content of pages and `data-bc-hook="product-container"` for the main product container on product pages
