### PR TITLE
Sidecar v2.16.0

### DIFF
--- a/source/cart.html
+++ b/source/cart.html
@@ -46,9 +46,24 @@
               </a>
               <div class="option-name">
                 {% unless item.product.has_default_option %}
-                  {{ item.option.name }} - <span class="cart-item-unit-price">{{ item.unit_price | money: theme.money_format }}</span>
+                  {{ item.option.name }} -
+                  <span class="cart-item-unit-price">
+                    {% if theme.show_strikethrough_pricing and item.original_unit_price > item.unit_price %}
+                      <s class="price-compare">{{ item.original_unit_price | money: theme.money_format }}</s>
+                      <span class="price-sale">{{ item.unit_price | money: theme.money_format }}</span>
+                    {% else %}
+                      {{ item.unit_price | money: theme.money_format }}
+                    {% endif %}
+                  </span>
                 {% else %}
-                  <div class="cart-item-unit-price">{{ item.unit_price | money: theme.money_format }}</div>
+                  <div class="cart-item-unit-price">
+                    {% if theme.show_strikethrough_pricing and item.original_unit_price > item.unit_price %}
+                      <s class="price-compare">{{ item.original_unit_price | money: theme.money_format }}</s>
+                      <span class="price-sale">{{ item.unit_price | money: theme.money_format }}</span>
+                    {% else %}
+                      {{ item.unit_price | money: theme.money_format }}
+                    {% endif %}
+                  </div>
                 {% endunless %}
               </div>
             </div>

--- a/source/home.html
+++ b/source/home.html
@@ -152,7 +152,32 @@
                       {% endif %}
 
                       {% unless hide_price %}
-                        {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                        {% assign show_strikethrough = false %}
+                        {% assign strikethrough_regular = nil %}
+                        {% assign strikethrough_sale = nil %}
+
+                        {% if theme.show_strikethrough_pricing %}
+                          {% if product.variable_pricing == false and product.original_price > product.default_price %}
+                            {% assign show_strikethrough = true %}
+                            {% assign strikethrough_regular = product.original_price %}
+                            {% assign strikethrough_sale = product.default_price %}
+                          {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "min_only" and product.min_original_price > product.min_price %}
+                            {% assign show_strikethrough = true %}
+                            {% assign strikethrough_regular = product.min_original_price %}
+                            {% assign strikethrough_sale = product.min_price %}
+                          {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "max_only" and product.max_original_price > product.max_price %}
+                            {% assign show_strikethrough = true %}
+                            {% assign strikethrough_regular = product.max_original_price %}
+                            {% assign strikethrough_sale = product.max_price %}
+                          {% endif %}
+                        {% endif %}
+
+                        {% if show_strikethrough %}
+                          <s class="price-compare">{{ strikethrough_regular | money: theme.money_format }}</s>
+                          <span class="price-sale">{{ strikethrough_sale | money: theme.money_format }}</span>
+                        {% else %}
+                          {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                        {% endif %}
 
                         {% if product.price_suffix != blank %}
                           {% assign variable_price_shown = true %}

--- a/source/home.html
+++ b/source/home.html
@@ -172,7 +172,7 @@
                     {% unless hide_price %}
                       {% if product.options.size > 1 and theme.show_product_variant_count_in_grid %}
                         <div class="product-list-thumb-options-description">
-                          {{ product.options.size }} {{ t['products.variants'] }}
+                          {{ product.options.size }} {{ t['products.variants'] | downcase }}
                         </div>
                       {% endif %}
                     {% endunless %}

--- a/source/javascripts/cart.js
+++ b/source/javascripts/cart.js
@@ -171,10 +171,13 @@ processUpdate = (input, item_id, new_val, cart) => {
   if (new_val > 0) {
     for (itemIndex = 0; itemIndex < cart.items.length; itemIndex++) {
       if (cart.items[itemIndex].id == item_id) {
-        item_price = cart.items[itemIndex].price;
-        formatted_item_price = formatMoney(item_price, true, true);
-        let priceElement = document.querySelector('.cart-item-price__update[data-item-id="'+item_id+'"]');
-        htmlHighlight(priceElement,formatted_item_price);
+        var item = cart.items[itemIndex];
+        var item_price = item.price;
+        var priceElement = document.querySelector('.cart-item-price__update[data-item-id="'+item_id+'"]');
+
+        // Line total only shows sale price (no strikethrough - strikethrough is on unit price only)
+        var formattedPrice = formatMoney(item_price, true, true);
+        htmlHighlight(priceElement, formattedPrice);
       }
     }
   }

--- a/source/javascripts/product-option-groups.js
+++ b/source/javascripts/product-option-groups.js
@@ -93,13 +93,23 @@ function enableAddButton(updated_price, original_price) {
 
   // Update the price display area with variant-specific pricing
   var priceValue = $('.price-value');
-  if (updated_price && priceValue.length) {
-    var showStrikethrough = themeOptions.showStrikethroughPricing && original_price && parseFloat(original_price) > parseFloat(updated_price);
-
-    if (showStrikethrough) {
-      priceValue.html('<s class="price-compare">' + formatMoney(original_price, true, true) + '</s> <span class="price-sale">' + formatMoney(updated_price, true, true) + '</span>');
+  if (priceValue.length) {
+    if (!updated_price) {
+      if (priceValue.data('original-html') !== undefined) {
+        priceValue.html(priceValue.data('original-html'));
+      }
     } else {
-      priceValue.html(formatMoney(updated_price, true, true));
+      if (priceValue.data('original-html') === undefined) {
+        priceValue.data('original-html', priceValue.html());
+      }
+
+      var showStrikethrough = themeOptions.showStrikethroughPricing && original_price && parseFloat(original_price) > parseFloat(updated_price);
+
+      if (showStrikethrough) {
+        priceValue.html('<s class="price-compare">' + formatMoney(original_price, true, true) + '</s> <span class="price-sale">' + formatMoney(updated_price, true, true) + '</span>');
+      } else {
+        priceValue.html(formatMoney(updated_price, true, true));
+      }
     }
   }
 

--- a/source/javascripts/product-option-groups.js
+++ b/source/javascripts/product-option-groups.js
@@ -81,20 +81,30 @@ Array.prototype.count = function (filterMethod) {
 };
 
 $('.product_option_select').on('change',function() {
-  var option_price = $(this).find("option:selected").attr("data-price");
-  enableAddButton(option_price);
+  var selectedOption = $(this).find("option:selected");
+  var option_price = selectedOption.attr("data-price");
+  var original_price = selectedOption.attr("data-original-price");
+  enableAddButton(option_price, original_price);
 });
-function enableAddButton(updated_price) {
+function enableAddButton(updated_price, original_price) {
   var addButton = $('.add-to-cart-button');
   var addButtonTitle = addButton.attr('data-add-title');
   addButton.attr("disabled",false);
-  if (updated_price) {
-    priceTitle = ' - ' + formatMoney(updated_price, true, true);
+
+  // Update the price display area with variant-specific pricing
+  var priceValue = $('.price-value');
+  if (updated_price && priceValue.length) {
+    var showStrikethrough = themeOptions.showStrikethroughPricing && original_price && parseFloat(original_price) > parseFloat(updated_price);
+
+    if (showStrikethrough) {
+      priceValue.html('<s class="price-compare">' + formatMoney(original_price, true, true) + '</s> <span class="price-sale">' + formatMoney(updated_price, true, true) + '</span>');
+    } else {
+      priceValue.html(formatMoney(updated_price, true, true));
+    }
   }
-  else {
-    priceTitle = '';
-  }
-  addButton.find('.button-text').html(addButtonTitle + priceTitle);
+
+  // Button shows only title, no price
+  addButton.find('.button-text').html(addButtonTitle);
   updateInventoryMessage($('#option').val());
   showBnplMessaging(updated_price, { alignment: 'left', displayMode: 'grid', pageType: 'product' });
 }
@@ -244,6 +254,20 @@ function processProduct(product) {
         enableSelectOption($(element));
       }
     });
+    // Restore the original price display (decode HTML entities from escaped attribute)
+    var priceValue = $('.price-value');
+    if (priceValue.length && priceValue.attr('data-original-price')) {
+      var decodedHtml = $('<div>').html(priceValue.attr('data-original-price')).text();
+      // If the original contained HTML tags, restore them; otherwise just use decoded text
+      var originalAttr = priceValue.attr('data-original-price');
+      if (originalAttr.indexOf('&lt;') !== -1) {
+        // Contains escaped HTML - decode and set as HTML
+        priceValue.html($('<div>').html(originalAttr).html());
+      } else {
+        // Plain text price
+        priceValue.text(originalAttr);
+      }
+    }
     setInitialProductOptionStatuses(product);
   })
 }
@@ -455,7 +479,7 @@ function processAvailableDropdownOptions(product, changed_dropdown) {
     if (product_option) {
       if (!product_option.sold_out && product_option.id > 0) {
         $('#option').val(product_option.id);
-        enableAddButton(product_option.price);
+        enableAddButton(product_option.price, product_option.original_price);
         if (num_option_groups > 1) {
           $('.reset-selection-button-container').fadeIn('fast');
         }

--- a/source/layout.html
+++ b/source/layout.html
@@ -458,6 +458,7 @@
         homepageSlideshowTransition: "{{ theme.homepage_slideshow_transition }}",
         homepageSlideshowLink: "{{ theme.homepage_slideshow_link }}",
         showBnplMessaging: {{ theme.show_bnpl_messaging }} && !themeFeatures.optOuts.includes("theme_bnpl_messaging"),
+        showStrikethroughPricing: {{ theme.show_strikethrough_pricing }},
       };
       const themeColors = {
         backgroundColor: '{{ theme.background_color }}',

--- a/source/product.html
+++ b/source/product.html
@@ -16,9 +16,19 @@
                 {% endif %}
                   <img
                     alt="Image {{ forloop.index }} of {{ product.name | escape }}"
-                    class="product-image lazyload"
+                    class="product-image{% unless forloop.index == 1 %} lazyload{% endunless %}"
                     {% if forloop.index == 1 %}fetchpriority="high"{% else %}loading="lazy"{% endif %}
                     src="{{ image | product_image_url | constrain: 200 }}"
+                    {% if forloop.index == 1 %}
+                    srcset="
+                      {{ image | product_image_url | constrain: 400 }} 400w,
+                      {{ image | product_image_url | constrain: 700 }} 700w,
+                      {{ image | product_image_url | constrain: 1000 }} 1000w,
+                      {{ image | product_image_url | constrain: 1400 }} 1400w,
+                      {{ image | product_image_url | constrain: 2000 }} 2000w,
+                    "
+                    sizes="(min-width: 768px) 50vw, 100vw"
+                    {% else %}
                     data-srcset="
                       {{ image | product_image_url | constrain: 400 }} 400w,
                       {{ image | product_image_url | constrain: 700 }} 700w,
@@ -26,9 +36,10 @@
                       {{ image | product_image_url | constrain: 1400 }} 1400w,
                       {{ image | product_image_url | constrain: 2000 }} 2000w,
                     "
+                    data-sizes="auto"
+                    {% endif %}
                     width="{{ image.height | times: aspect_ratio }}"
                     height="{{ image.height }}"
-                    data-sizes="auto"
                   >
                 {% if theme.product_image_zoom %}</a>{% else %}</div>{% endif %}
               </div>
@@ -86,17 +97,17 @@
       {% endif %}
         <img
           alt="{{ product.name | escape }}"
-          class="blur-up product-image lazyload"
+          class="blur-up product-image"
           fetchpriority="high"
           src="{{ product.image | product_image_url | constrain: 200 }}"
-          data-srcset="
+          srcset="
             {{ product.image | product_image_url | constrain: 400 }} 400w,
             {{ product.image | product_image_url | constrain: 700 }} 700w,
             {{ product.image | product_image_url | constrain: 1000 }} 1000w,
             {{ product.image | product_image_url | constrain: 1400 }} 1400w,
             {{ product.image | product_image_url | constrain: 2000 }} 2000w,
           "
-          data-sizes="auto"
+          sizes="(min-width: 768px) 50vw, 100vw"
         >
       {% if theme.product_image_zoom %}</a>{% else %}</div>{% endif %}
     {% endif %}

--- a/source/product.html
+++ b/source/product.html
@@ -63,6 +63,7 @@
                 <img
                   alt=""
                   class="lazyload"
+                  loading="lazy"
                   src="{{ image | product_image_url | constrain: 150 }}"
                   data-srcset="
                     {{ image | product_image_url | constrain: 250 }} 250w,
@@ -341,6 +342,7 @@
                   <img
                     alt=""
                     class="blur-up product-list-image lazyload grid-{{ theme.grid_image_style }}"
+                    loading="lazy"
                     src="{{ related_product.image | product_image_url | constrain: 20 }}"
                     {% unless theme.grid_image_style == 'default' %}data-aspectratio="{{ aspect_ratio }}"{% endunless %}
                     data-srcset="

--- a/source/product.html
+++ b/source/product.html
@@ -357,7 +357,7 @@
                     {% unless hide_price %}
                       {% if related_product.options.size > 1 and theme.show_product_variant_count_in_grid %}
                         <div class="product-list-thumb-options-description">
-                          {{ related_product.options.size }} {{ t['products.variants'] }}
+                          {{ related_product.options.size }} {{ t['products.variants'] | downcase }}
                         </div>
                       {% endif %}
                     {% endunless %}

--- a/source/product.html
+++ b/source/product.html
@@ -134,7 +134,20 @@
     {% capture product_status_class %}{% if product.status == 'active' and product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
     <div class="price">
       {% unless hide_price %}
-        {{ product | product_price: theme.money_format }}
+        {% assign show_strikethrough = false %}
+        {% if theme.show_strikethrough_pricing and product.variable_pricing == false and product.original_price > product.default_price %}
+          {% assign show_strikethrough = true %}
+        {% endif %}
+
+        {% capture original_price_html %}{% if show_strikethrough %}<s class="price-compare">{{ product.original_price | money: theme.money_format }}</s> <span class="price-sale">{{ product.default_price | money: theme.money_format }}</span>{% else %}{{ product | product_price: theme.money_format }}{% endif %}{% endcapture %}
+        <span class="price-value" data-original-price="{{ original_price_html | escape }}">
+          {% if show_strikethrough %}
+            <s class="price-compare">{{ product.original_price | money: theme.money_format }}</s>
+            <span class="price-sale">{{ product.default_price | money: theme.money_format }}</span>
+          {% else %}
+            {{ product | product_price: theme.money_format }}
+          {% endif %}
+        </span>
 
         {% if product.price_suffix != blank %}
           {% assign variable_price_shown = true %}
@@ -180,10 +193,25 @@
               {% for option_group in product.option_groups %}
                 <div class="select">
                   <div class="select-wrapper">
-                    <select data-unavailable-text="(Unavailable)" data-sold-text="({{ t['products.sold_out'] }})" data-group-id="{{ option_group.id }}" data-group-name="{{ option_group.name | escape }}" class="product_option_group" name="option_group[{{ option_group.id }}]" aria-label="Select {{ option_group.name | escape }}" required>
+                    <select data-unavailable-text="(Unavailable)" data-sold-text="({{ t['products.sold_out'] | downcase }})" data-group-id="{{ option_group.id }}" data-group-name="{{ option_group.name | escape }}" class="product_option_group" name="option_group[{{ option_group.id }}]" aria-label="Select {{ option_group.name | escape }}" required>
                       <option value="" disabled="disabled" selected>{{ option_group.name }}</option>
                       {% for value in option_group.values %}
-                        <option value="{{ value.id }}" data-name="{{ value.name | escape }}">{{ value.name }}</option>
+                        {% assign option_status_label = '' %}
+                        {% if product.option_groups.size == 1 and theme.show_sale_label_in_product_options %}
+                          {% for option in product.options %}
+                            {% for ogv in option.option_group_values %}
+                              {% if ogv.id == value.id %}
+                                {% if option.sold_out %}
+                                  {% assign option_status_label = t['products.sold_out'] | downcase %}
+                                {% elsif option.original_price > option.price %}
+                                  {% assign option_status_label = t['products.on_sale'] | downcase %}
+                                {% endif %}
+                                {% break %}
+                              {% endif %}
+                            {% endfor %}
+                          {% endfor %}
+                        {% endif %}
+                        <option value="{{ value.id }}" data-name="{{ value.name | escape }}">{{ value.name }}{% if option_status_label != blank %} ({{ option_status_label }}){% endif %}</option>
                       {% endfor %}
                     </select>
                     <svg aria-hidden="true" fill="currentColor" xmlns="http://www.w3.org/2000/svg" width="14"><path d="M14 1h-1c0-1 0-1 0 0L7 6 1 1c0-1 0-1 0 0H0v1l7 6 7-6V1Z"></path></svg>
@@ -197,7 +225,7 @@
                 <select class="product_option_select" id="option" name="cart[add][id]" aria-label="{{ t['products.select_variant'] }}" required>
                   <option value="" disabled="disabled" selected>{{ t['products.select_variant'] }}</option>
                   {% for option in product.options %}
-                    <option value="{{ option.id }}" data-price="{{ option.price }}"{% if option.sold_out %} disabled="disabled" disabled-type="sold-out"{% endif %}>{{ option.name }} {% if option.sold_out %} ({{ t['products.sold_out'] }}){% endif %}</option>
+                    <option value="{{ option.id }}" data-price="{{ option.price }}" data-original-price="{{ option.original_price }}"{% if option.sold_out %} disabled="disabled" disabled-type="sold-out"{% endif %}>{{ option.name }}{% if option.sold_out %} ({{ t['products.sold_out'] | downcase }}){% elsif option.original_price > option.price and theme.show_sale_label_in_product_options %} ({{ t['products.on_sale'] | downcase }}){% endif %}</option>
                   {% endfor %}
                 </select>
                 <svg aria-hidden="true" fill="currentColor" xmlns="http://www.w3.org/2000/svg" width="14"><path d="M14 1h-1c0-1 0-1 0 0L7 6 1 1c0-1 0-1 0 0H0v1l7 6 7-6V1Z"></path></svg>
@@ -333,7 +361,32 @@
                       {% endif %}
 
                       {% unless hide_price %}
-                        {{ related_product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                        {% assign show_strikethrough = false %}
+                        {% assign strikethrough_regular = nil %}
+                        {% assign strikethrough_sale = nil %}
+
+                        {% if theme.show_strikethrough_pricing %}
+                          {% if related_product.variable_pricing == false and related_product.original_price > related_product.default_price %}
+                            {% assign show_strikethrough = true %}
+                            {% assign strikethrough_regular = related_product.original_price %}
+                            {% assign strikethrough_sale = related_product.default_price %}
+                          {% elsif related_product.variable_pricing and theme.product_variable_pricing_display_format == "min_only" and related_product.min_original_price > related_product.min_price %}
+                            {% assign show_strikethrough = true %}
+                            {% assign strikethrough_regular = related_product.min_original_price %}
+                            {% assign strikethrough_sale = related_product.min_price %}
+                          {% elsif related_product.variable_pricing and theme.product_variable_pricing_display_format == "max_only" and related_product.max_original_price > related_product.max_price %}
+                            {% assign show_strikethrough = true %}
+                            {% assign strikethrough_regular = related_product.max_original_price %}
+                            {% assign strikethrough_sale = related_product.max_price %}
+                          {% endif %}
+                        {% endif %}
+
+                        {% if show_strikethrough %}
+                          <s class="price-compare">{{ strikethrough_regular | money: theme.money_format }}</s>
+                          <span class="price-sale">{{ strikethrough_sale | money: theme.money_format }}</span>
+                        {% else %}
+                          {{ related_product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                        {% endif %}
 
                         {% if related_product.price_suffix != blank %}
                           {% assign variable_price_shown = true %}

--- a/source/product.html
+++ b/source/product.html
@@ -230,11 +230,7 @@
       </form>
     {% endif %}
 
-    {% if product.description != blank %}
-      <div class="product-description body-text">
-        {{ product.description | paragraphs }}
-      </div>
-    {% endif %}
+    <div class="product-description body-text" data-bc-hook="product-description">{%- if product.description != blank %}{{ product.description | paragraphs }}{% endif -%}</div>
 
     {% if theme.show_inventory_bars %}
       {% case product.status %}

--- a/source/products.html
+++ b/source/products.html
@@ -98,7 +98,7 @@
                   {% unless hide_price %}
                     {% if product.options.size > 1 and theme.show_product_variant_count_in_grid %}
                       <div class="product-list-thumb-options-description">
-                        {{ product.options.size }} {{ t['products.variants'] }}
+                        {{ product.options.size }} {{ t['products.variants'] | downcase }}
                       </div>
                     {% endif %}
                   {% endunless %}

--- a/source/products.html
+++ b/source/products.html
@@ -78,7 +78,32 @@
                     {% endif %}
 
                     {% unless hide_price %}
-                      {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                      {% assign show_strikethrough = false %}
+                      {% assign strikethrough_regular = nil %}
+                      {% assign strikethrough_sale = nil %}
+
+                      {% if theme.show_strikethrough_pricing %}
+                        {% if product.variable_pricing == false and product.original_price > product.default_price %}
+                          {% assign show_strikethrough = true %}
+                          {% assign strikethrough_regular = product.original_price %}
+                          {% assign strikethrough_sale = product.default_price %}
+                        {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "min_only" and product.min_original_price > product.min_price %}
+                          {% assign show_strikethrough = true %}
+                          {% assign strikethrough_regular = product.min_original_price %}
+                          {% assign strikethrough_sale = product.min_price %}
+                        {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "max_only" and product.max_original_price > product.max_price %}
+                          {% assign show_strikethrough = true %}
+                          {% assign strikethrough_regular = product.max_original_price %}
+                          {% assign strikethrough_sale = product.max_price %}
+                        {% endif %}
+                      {% endif %}
+
+                      {% if show_strikethrough %}
+                        <s class="price-compare">{{ strikethrough_regular | money: theme.money_format }}</s>
+                        <span class="price-sale">{{ strikethrough_sale | money: theme.money_format }}</span>
+                      {% else %}
+                        {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                      {% endif %}
 
                       {% if product.price_suffix != blank %}
                         {% assign variable_price_shown = true %}

--- a/source/settings.json
+++ b/source/settings.json
@@ -284,7 +284,7 @@
               "button_text_color": "#FFFFFF",
               "button_background_color": "#FF3E6C",
               "button_background_hover_color": "#FF6688",
-              "product_status_text_color_primary": "#1A2E44",
+              "product_status_text_color_primary": "#FF3E6C",
               "product_status_text_color_secondary": "#B8C4E8",
               "inventory_status_text_color": "#4ECDC4",
               "announcement_message_background_color": "#4ECDC4",

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Sidecar",
-  "version": "2.15.5",
+  "version": "2.16.0",
   "images": [
     {
       "variable": "logo_image",

--- a/source/settings.json
+++ b/source/settings.json
@@ -609,7 +609,8 @@
       "options": [
         ["Default (Sentence case)", "initial"],
         ["Uppercase", "uppercase"],
-        ["Lowercase", "lowercase"]
+        ["Lowercase", "lowercase"],
+        ["Titlecase", "capitalize"]
       ],
       "default": "initial",
       "description": "Controls the text case styling in your main navigation"
@@ -622,7 +623,8 @@
       "options": [
         ["Default (Sentence case)", "initial"],
         ["Uppercase", "uppercase"],
-        ["Lowercase", "lowercase"]
+        ["Lowercase", "lowercase"],
+        ["Titlecase", "capitalize"]
       ],
       "default": "initial",
       "description": "Controls the text case styling in the footer, excluding custom footer text"

--- a/source/settings.json
+++ b/source/settings.json
@@ -932,6 +932,25 @@
       "description": "Choose how to display prices in your product grid when a product's variants have different prices. Individual product pages will always show the full range."
     },
     {
+      "variable": "show_strikethrough_pricing",
+      "label": "Show strikethrough pricing",
+      "section": "product_page",
+      "type": "boolean",
+      "default": true,
+      "description": "Show the original price crossed out next to the sale price",
+      "requires": [
+        "feature:theme_strikethrough_pricing eq visible"
+      ]
+    },
+    {
+      "variable": "show_sale_label_in_product_options",
+      "label": "Show sale label in variant dropdowns",
+      "section": "product_page",
+      "type": "boolean",
+      "default": true,
+      "description": "Adds a sale indicator next to discounted variants in the dropdown"
+    },
+    {
       "variable": "show_product_variant_count_in_grid",
       "label": "Show product variant count in product grids",
       "section": "product_page",

--- a/source/stylesheets/cart.sass
+++ b/source/stylesheets/cart.sass
@@ -70,6 +70,13 @@
   .option-name
     font-size: .925rem
 
+  .cart-item-unit-price
+    .price-compare
+      opacity: 0.6
+      margin-right: 6px
+      text-decoration: line-through
+      font-size: 0.9em
+
   input
     height: 100%
     padding: 8px

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -66,10 +66,11 @@
     .status
       font-style: normal
       font-size: calc(0.925rem * min(var(--product-title-scale, 1), 1.3))
-      
+      margin-left: 2px
+
       &.status-primary
         color: var(--product-status-text-color-primary)
-    
+
       &.status-secondary
         color: var(--product-status-text-color-secondary)
 

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -186,6 +186,11 @@
       font-style: normal
       margin-left: auto
 
+.product-form select span, .product-form select span option
+  display: none
+  opacity: 0
+  visibility: hidden
+
 .product-form-cart-linker
   display: grid
   grid-template-rows: 0fr

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -63,6 +63,12 @@
       font-size: calc(1.125rem * var(--product-title-scale, 1))
       margin: 4px 0 12px
 
+      .price-compare
+        opacity: 0.6
+        margin-right: 6px
+        text-decoration: line-through
+        font-size: 0.9em
+
     .status
       font-style: normal
       font-size: calc(0.925rem * min(var(--product-title-scale, 1), 1.3))

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -111,6 +111,9 @@
     padding-top: 16px
     font-size: calc(1rem * var(--product-description-scale, 1))
 
+    &:empty
+      display: none
+
     a
       text-decoration: underline
 

--- a/source/stylesheets/products.sass
+++ b/source/stylesheets/products.sass
@@ -158,6 +158,12 @@ a.prod-thumb
   margin-top: 4px
   font-size: calc(0.9rem * var(--product-grid-scale, 1))
 
+  .price-compare
+    opacity: 0.6
+    margin-right: 6px
+    text-decoration: line-through
+    font-size: 0.9em
+
 .price-suffix
   white-space: nowrap
 


### PR DESCRIPTION
## Summary

### Features
- **Strikethrough pricing** — Display original prices with strikethrough when items are on sale
- **Titlecase nav text transformation** — New option to apply titlecase formatting to navigation text

### Fixes
- **Product description container always in DOM** — The product description container is now always rendered (with a `data-bc-hook`) so it can be targeted by JS, and hidden via CSS `:empty` when there's no description
- **Product page status text padding** — Tweaked left padding for status text on product pages
- **Playful #3 style status text color** — Corrected primary status text color in the Playful #3 style preset

### Chores
- Lowercase label for options text in product grid
- Version bump to 2.16.0